### PR TITLE
Update xgo version.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,7 +221,7 @@ jobs:
       - run:
           name: Install xgo
           command: |
-            go install -v github.com/pastelnetwork/xgo@48be1f35b934924c998997a8470ffdb6a022b968
+            go install -v github.com/pastelnetwork/xgo@cfada204f14596d56540b02e38526a56d57ddc30
       - create-sources-container:
           containerName: "sourcesContainer"
       - build:


### PR DESCRIPTION
- xgo is switched to build with images from `pastelnetworkofficial` dockerhub account
- https://github.com/pastelnetwork/xgo/blob/main/Dockerfile#L10 GoLang image is patched to increase CGO pthreads stack size on MacOS to 2 MB (to avoid crash on CGO call of native Legroast library)