### PR TITLE
[Dupe detection] cmaes enable ordering

### DIFF
--- a/dupe-detection/cmd/optimizer/optimizer.go
+++ b/dupe-detection/cmd/optimizer/optimizer.go
@@ -5,9 +5,12 @@ import (
 	"fmt"
 	"log"
 	"math/rand"
+	"strings"
 	"time"
 
 	"github.com/c-bata/goptuna"
+	"github.com/gitchander/permutation"
+	combinations "github.com/mxschmitt/golang-combinations"
 	"gorm.io/driver/mysql"
 
 	"github.com/c-bata/goptuna/cmaes"
@@ -85,19 +88,18 @@ func objective(trial goptuna.Trial) (float64, error) {
 	config.HoeffdingRound2DupeThreshold, _ = trial.SuggestFloat("HoeffdingD2", 0.1, 0.99999)
 	if err != nil {
 		return 0, errors.New(err)
-	}
+	}*/
 
 	allCombinationsOfUnstableMethods := combinations.All(config.UnstableOrderOfCorrelationMethods)
 	var allOrderedCombinationsOfUnstableMethodsAsStrings []string
 	for _, combination := range allCombinationsOfUnstableMethods {
 		permutator := permutation.New(permutation.StringSlice(combination))
 		for permutator.Next() {
-			fmt.Println(combination)
 			allOrderedCombinationsOfUnstableMethodsAsStrings = append(allOrderedCombinationsOfUnstableMethodsAsStrings, strings.Join(combination, " "))
 		}
-	}*/
+	}
 
-	/*correlationMethodIndex, err := trial.SuggestStepInt("CorrelationMethodsOrderIndex", 0, len(allOrderedCombinationsOfUnstableMethodsAsStrings)-1, 1)
+	correlationMethodIndex, err := trial.SuggestStepInt("CorrelationMethodsOrderIndex", 0, len(allOrderedCombinationsOfUnstableMethodsAsStrings)-1, 1)
 	if err != nil {
 		return 0, errors.New(err)
 	}
@@ -105,10 +107,10 @@ func objective(trial goptuna.Trial) (float64, error) {
 	config.CorrelationMethodsOrder = strings.Join(correlationMethodsOrder, " ")
 	if err != nil {
 		return 0, errors.New(err)
-	}*/
+	}
 
 	//config.CorrelationMethodsOrder = "MI PearsonR SpearmanRho BootstrappedKendallTau BootstrappedBlomqvistBeta HoeffdingDRound1 HoeffdingDRound2"
-	config.CorrelationMethodsOrder = "PearsonR SpearmanRho KendallTau HoeffdingD BlomqvistBeta"
+	//config.CorrelationMethodsOrder = "PearsonR SpearmanRho KendallTau HoeffdingD BlomqvistBeta"
 
 	err = trial.SetUserAttr("CorrelationMethodsOrder", config.CorrelationMethodsOrder)
 	if err != nil {
@@ -139,7 +141,7 @@ func objective(trial goptuna.Trial) (float64, error) {
 	if err != nil {
 		return 0, errors.New(err)
 	}
-	return aurpcResult.AUPRC, nil
+	return 1.0 - aurpcResult.AUPRC, nil
 }
 
 func runStudy(studyName string) error {
@@ -157,8 +159,6 @@ func runStudy(studyName string) error {
 		studyName,
 		goptuna.StudyOptionStorage(storage),
 		goptuna.StudyOptionRelativeSampler(cmaes.NewSampler()),
-		//goptuna.StudyOptionSampler(tpe.NewSampler()),
-		goptuna.StudyOptionDirection(goptuna.StudyDirectionMaximize),
 		goptuna.StudyOptionLoadIfExists(true),
 	)
 	if err != nil {

--- a/dupe-detection/cmd/optimizer/optimizer.go
+++ b/dupe-detection/cmd/optimizer/optimizer.go
@@ -52,10 +52,10 @@ func objective(trial goptuna.Trial) (float64, error) {
 		return 0, errors.New(err)
 	}
 
-	/*config.MIThreshold, err = trial.SuggestFloat("MIThreshold", 5.2, 5.4)
+	config.MIThreshold, err = trial.SuggestFloat("MIThreshold", 5.2, 5.4)
 	if err != nil {
 		return 0, errors.New(err)
-	}*/
+	}
 
 	config.PearsonDupeThreshold, err = trial.SuggestFloat("Pearson", 0.99, 0.99999)
 	if err != nil {

--- a/dupe-detection/pkg/auprc/auprc.go
+++ b/dupe-detection/pkg/auprc/auprc.go
@@ -413,6 +413,9 @@ type MeasureResult struct {
 	AverageAccuracy  float64
 }
 
+var finalCombinedImageFingerprintArray [][]float64
+var memoizationData *dupedetection.MemoizationImageData
+
 // MeasureAUPRC calculates AUPRC for a test corpus of the images
 func MeasureAUPRC(config dupedetection.ComputeConfig) (MeasureResult, error) {
 	defer pruntime.PrintExecutionTime(time.Now())
@@ -443,9 +446,12 @@ func MeasureAUPRC(config dupedetection.ComputeConfig) (MeasureResult, error) {
 
 	fmt.Printf("\nRetrieving image fingerprints of previously registered images from local database...")
 
-	finalCombinedImageFingerprintArray, memoizationData, err := getAllImageFingerprintsFromDupeDetectionDatabaseAsArray()
-	if err != nil {
-		return MeasureResult{}, errors.New(err)
+	var err error
+	if len(finalCombinedImageFingerprintArray) == 0 || memoizationData == nil {
+		finalCombinedImageFingerprintArray, memoizationData, err = getAllImageFingerprintsFromDupeDetectionDatabaseAsArray()
+		if err != nil {
+			return MeasureResult{}, errors.New(err)
+		}
 	}
 
 	fmt.Printf("\n\nNow testing duplicate-detection scheme on known near-duplicate images:")

--- a/dupe-detection/pkg/dupedetection/dupedetection.go
+++ b/dupe-detection/pkg/dupedetection/dupedetection.go
@@ -899,13 +899,13 @@ func NewComputeConfig() ComputeConfig {
 	config.StableOrderOfCorrelationMethods = []string{
 		"PearsonR",
 		"SpearmanRho",
-		"BootstrappedKendallTau",
 	}
 
 	config.UnstableOrderOfCorrelationMethods = []string{
-		"BootstrappedBlomqvistBeta",
-		"HoeffdingDRound1",
-		"HoeffdingDRound2",
+		"MI",
+		"KendallTau",
+		"HoeffdingD",
+		"BlomqvistBeta",
 	}
 
 	return config


### PR DESCRIPTION
- Caching of fingerprints retrieved from database (increases fully memoized trial execution on ~25% - takes 2-3 seconds now)
- cmaes reconfigured to find the minimal value instead of maximum (seems it works better)
- MI is enabled again
- cmaes suggest order of calculation methods ( here cmaes doesn't work as expected )