### PR TITLE
Fix issues with ArtReg workflow

### DIFF
--- a/common/service/artwork/file.go
+++ b/common/service/artwork/file.go
@@ -58,7 +58,12 @@ func (file *File) SetFormat(format Format) error {
 	file.format = format
 
 	newname := fmt.Sprintf("%s.%s", strings.TrimSuffix(file.name, filepath.Ext(file.name)), format)
+	oldname := file.name
 	file.name = newname
+
+	if err := file.storage.Update(oldname, newname, file); err != nil {
+		return err
+	}
 
 	if !file.isCreated {
 		return nil

--- a/common/service/artwork/storage.go
+++ b/common/service/artwork/storage.go
@@ -53,6 +53,22 @@ func (storage *Storage) File(name string) (*File, error) {
 	return file, nil
 }
 
+// Update changes the key to identify a *File to a new key
+func (storage *Storage) Update(oldname, newname string, file *File) error {
+	f, ok := storage.files[oldname]
+	if !ok {
+		return errors.New("file not found")
+	}
+
+	if f != file {
+		return errors.New("not the same file")
+	}
+
+	delete(storage.files, oldname)
+	storage.files[newname] = file
+	return nil
+}
+
 // NewStorage returns a new Storage instance.
 func NewStorage(storage storage.FileStorage) *Storage {
 	prefix, _ := random.String(8, random.Base62Chars)

--- a/common/service/artwork/storage_test.go
+++ b/common/service/artwork/storage_test.go
@@ -1,0 +1,35 @@
+package artwork
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pastelnetwork/gonode/common/storage/fs"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_StoreFileAfterSetFormat(t *testing.T) {
+	storage := NewStorage(fs.NewFileStorage(os.TempDir()))
+
+	files := []struct {
+		name   string
+		format Format
+	}{
+		{"test.jpeg", JPEG},
+		{"test.jpg", JPEG},
+		{"test.png", PNG}}
+
+	for _, file := range files {
+		f := storage.NewFile()
+		assert.NotNil(t, f)
+
+		//
+		err := f.SetFormatFromExtension(filepath.Ext(file.name))
+		assert.Equal(t, nil, err)
+		assert.Equal(t, file.format, f.format)
+
+		_, err = storage.File(f.Name())
+		assert.Equal(t, nil, err)
+	}
+}

--- a/walletnode/api/services/artwork.go
+++ b/walletnode/api/services/artwork.go
@@ -140,7 +140,7 @@ func (service *Artwork) UploadImage(_ context.Context, p *artworks.UploadImagePa
 // Mount configures the mux to serve the artworks endpoints.
 func (service *Artwork) Mount(ctx context.Context, mux goahttp.Muxer) goahttp.Server {
 	endpoints := artworks.NewEndpoints(service)
-	srv := server.New(endpoints, nil, goahttp.RequestDecoder, goahttp.ResponseEncoder, api.ErrorHandler, nil, &websocket.Upgrader{}, nil, UploadImageDecoderFunc(ctx, service))
+	srv := server.New(endpoints, mux, goahttp.RequestDecoder, goahttp.ResponseEncoder, api.ErrorHandler, nil, &websocket.Upgrader{}, nil, UploadImageDecoderFunc(ctx, service))
 	server.Mount(mux, srv)
 
 	for _, m := range srv.Mounts {

--- a/walletnode/services/artworkregister/service.go
+++ b/walletnode/services/artworkregister/service.go
@@ -83,7 +83,10 @@ func (service *Service) Tasks() []*Task {
 
 // Task returns the task of the registration artwork by the given id.
 func (service *Service) Task(id string) *Task {
-	return service.Worker.Task(id).(*Task)
+	if t := service.Worker.Task(id); t != nil {
+		return t.(*Task)
+	}
+	return nil
 }
 
 // AddTask runs a new task of the registration artwork and returns its taskID.


### PR DESCRIPTION
Fix the following issues
- Upload file failed with `file not found` error
- GET artworks/register/{taskId} crashes wallet node
- GET artworks/register/{taskId}/states crashes wallet node 