### PR TITLE
fix breaking APIs (APIs with path params)

### DIFF
--- a/walletnode/api/services/artwork.go
+++ b/walletnode/api/services/artwork.go
@@ -140,7 +140,7 @@ func (service *Artwork) UploadImage(_ context.Context, p *artworks.UploadImagePa
 // Mount configures the mux to serve the artworks endpoints.
 func (service *Artwork) Mount(ctx context.Context, mux goahttp.Muxer) goahttp.Server {
 	endpoints := artworks.NewEndpoints(service)
-	srv := server.New(endpoints, nil, goahttp.RequestDecoder, goahttp.ResponseEncoder, api.ErrorHandler, nil, &websocket.Upgrader{}, nil, UploadImageDecoderFunc(ctx, service))
+	srv := server.New(endpoints, mux, goahttp.RequestDecoder, goahttp.ResponseEncoder, api.ErrorHandler, nil, &websocket.Upgrader{}, nil, UploadImageDecoderFunc(ctx, service))
 	server.Mount(mux, srv)
 
 	for _, m := range srv.Mounts {


### PR DESCRIPTION
Endpoints:
GET:  http://localhost:8080/artworks/register/{taskID}/state
GET: http://localhost:8080/artworks/register/{taskID}
are crashing the walletnode and the error leads to some auto-genrated code which is not very useful. 
I found this bug, this will fix the issue of breaking APIs. 
https://blockchain-devel.slack.com/archives/C01SLR99SAK/p1624452605028400
