### PR TITLE
refactor thumbnail fetch to use supernode & rqlite

### DIFF
--- a/walletnode/api/services/artwork.go
+++ b/walletnode/api/services/artwork.go
@@ -188,11 +188,10 @@ func (service *Artwork) ArtworkGet(ctx context.Context, p *artworks.ArtworkGetPa
 	}
 
 	res = toArtworkDetail(ticket)
-	data, err := service.search.FetchThumbnail(ctx, ticket)
+	data, err := service.search.GetThumbnail(ctx, ticket)
 	if err != nil {
 		return nil, artworks.MakeInternalServerError(err)
 	}
-
 	res.Thumbnail = data
 
 	return res, nil

--- a/walletnode/cmd/app.go
+++ b/walletnode/cmd/app.go
@@ -127,7 +127,7 @@ func runApp(ctx context.Context, config *configs.Config) error {
 
 	// business logic services
 	artworkRegister := artworkregister.NewService(&config.ArtworkRegister, db, fileStorage, pastelClient, nodeClient)
-	artworkSearch := artworksearch.NewService(pastelClient, p2p)
+	artworkSearch := artworksearch.NewService(&config.ArtworkSearch, pastelClient, p2p, nodeClient)
 	// api service
 	server := api.NewServer(config.API,
 		services.NewArtwork(artworkRegister, artworkSearch),

--- a/walletnode/configs/node.go
+++ b/walletnode/configs/node.go
@@ -3,18 +3,21 @@ package configs
 import (
 	"github.com/pastelnetwork/gonode/walletnode/api"
 	"github.com/pastelnetwork/gonode/walletnode/services/artworkregister"
+	"github.com/pastelnetwork/gonode/walletnode/services/artworksearch"
 )
 
 // Node contains the SuperNode configuration itself.
 type Node struct {
 	// `squash` field cannot be pointer
 	ArtworkRegister artworkregister.Config `mapstructure:",squash" json:"artwork_register,omitempty"`
+	ArtworkSearch   artworksearch.Config   `mapstructure:",squash" json:"artwork_search,omitempty"`
 	API             *api.Config            `mapstructure:"api" json:"api,omitempty"`
 }
 
 // NewNode returns a new Node instance
 func NewNode() Node {
 	return Node{
+		ArtworkSearch:   *artworksearch.NewConfig(),
 		ArtworkRegister: *artworkregister.NewConfig(),
 		API:             api.NewConfig(),
 	}

--- a/walletnode/node/test/mock_client.go
+++ b/walletnode/node/test/mock_client.go
@@ -72,8 +72,13 @@ func (client *Client) AssertRegisterArtworkCall(expectedCalls int, arguments ...
 }
 
 // ListenOnConnect listening Connect call and returns error from args
-func (client *Client) ListenOnConnect(returnErr error) *Client {
-	client.Client.On(ConnectMethod, mock.Anything, mock.IsType(string(""))).Return(client.Connection, returnErr)
+func (client *Client) ListenOnConnect(addr string, returnErr error) *Client {
+	if addr == "" {
+		client.Client.On(ConnectMethod, mock.Anything, mock.IsType(string(""))).Return(client.Connection, returnErr)
+	} else {
+		client.Client.On(ConnectMethod, mock.Anything, addr).Return(client.Connection, returnErr)
+	}
+
 	return client
 }
 

--- a/walletnode/services/artworkregister/config.go
+++ b/walletnode/services/artworkregister/config.go
@@ -25,7 +25,6 @@ type Config struct {
 	// internal settings
 	connectToNextNodeDelay time.Duration
 	acceptNodesTimeout     time.Duration
-	connectTimeout         time.Duration
 
 	thumbnailSize int
 }
@@ -37,7 +36,6 @@ func NewConfig() *Config {
 
 		connectToNextNodeDelay: connectToNextNodeDelay,
 		acceptNodesTimeout:     acceptNodesTimeout,
-		connectTimeout:         connectTimeout,
 
 		thumbnailSize: thumbnailSize,
 	}

--- a/walletnode/services/artworkregister/task.go
+++ b/walletnode/services/artworkregister/task.go
@@ -191,7 +191,7 @@ func (task *Task) meshNodes(ctx context.Context, nodes node.List, primaryIndex i
 	var meshNodes node.List
 
 	primary := nodes[primaryIndex]
-	if err := primary.Connect(ctx, task.config.connectTimeout); err != nil {
+	if err := primary.Connect(ctx, task.config.ConnectTimeout); err != nil {
 		return nil, err
 	}
 	if err := primary.Session(ctx, true); err != nil {
@@ -217,7 +217,7 @@ func (task *Task) meshNodes(ctx context.Context, nodes node.List, primaryIndex i
 				go func() {
 					defer errors.Recover(log.Fatal)
 
-					if err := node.Connect(ctx, task.config.connectTimeout); err != nil {
+					if err := node.Connect(ctx, task.config.ConnectTimeout); err != nil {
 						return
 					}
 					if err := node.Session(ctx, false); err != nil {

--- a/walletnode/services/artworkregister/task_test.go
+++ b/walletnode/services/artworkregister/task_test.go
@@ -126,7 +126,7 @@ func TestTaskRun(t *testing.T) {
 			t.Run(fmt.Sprintf("testCase-%d", i), func(t *testing.T) {
 				nodeClient := test.NewMockClient(t)
 				nodeClient.
-					ListenOnConnect(testCase.args.returnErr).
+					ListenOnConnect("", testCase.args.returnErr).
 					ListenOnRegisterArtwork().
 					ListenOnSession(testCase.args.returnErr).
 					ListenOnConnectTo(testCase.args.returnErr).
@@ -285,7 +285,7 @@ func TestTaskMeshNodes(t *testing.T) {
 			//create new client mock
 			nodeClient := test.NewMockClient(t)
 			nodeClient.
-				ListenOnConnect(testCase.args.returnErr).
+				ListenOnConnect("", testCase.args.returnErr).
 				ListenOnRegisterArtwork().
 				ListenOnSession(testCase.args.returnErr).
 				ListenOnConnectTo(testCase.args.returnErr).

--- a/walletnode/services/artworksearch/config.go
+++ b/walletnode/services/artworksearch/config.go
@@ -1,0 +1,17 @@
+package artworksearch
+
+import (
+	"github.com/pastelnetwork/gonode/walletnode/services/common"
+)
+
+// Config contains settings of the registering artwork.
+type Config struct {
+	*common.Config `mapstructure:",squash" json:"-"`
+}
+
+// NewConfig returns a new Config instance.
+func NewConfig() *Config {
+	return &Config{
+		Config: common.NewConfig(),
+	}
+}

--- a/walletnode/services/artworksearch/node/list.go
+++ b/walletnode/services/artworksearch/node/list.go
@@ -1,0 +1,67 @@
+package node
+
+import (
+	"context"
+
+	"github.com/pastelnetwork/gonode/common/errgroup"
+	"github.com/pastelnetwork/gonode/common/errors"
+)
+
+// List represents multiple Node.
+type List []*Node
+
+// Add adds a new node to the list.
+func (nodes *List) Add(node *Node) {
+	*nodes = append(*nodes, node)
+}
+
+// Activate marks all nodes as activated.
+// Since any node can be present in the same time in several List and Node is a pointer, this is reflected in all lists.
+func (nodes *List) Activate() {
+	for _, node := range *nodes {
+		node.activated = true
+	}
+}
+
+// DisconnectInactive disconnects nodes which were not marked as activated.
+func (nodes *List) DisconnectInactive() {
+	for _, node := range *nodes {
+		if node.Connection != nil && !node.activated {
+			node.Connection.Close()
+		}
+	}
+}
+
+// WaitConnClose waits for the connection closing by any supernodes.
+func (nodes *List) WaitConnClose(ctx context.Context) error {
+	group, ctx := errgroup.WithContext(ctx)
+
+	for _, node := range *nodes {
+		node := node
+		group.Go(func() error {
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-node.Connection.Done():
+				return errors.Errorf("%q unexpectedly closed the connection", node)
+			}
+		})
+	}
+
+	return group.Wait()
+}
+
+// FindByPastelID returns node by its patstelID.
+func (nodes List) FindByPastelID(id string) *Node {
+	for _, node := range nodes {
+		if node.pastelID == id {
+			return node
+		}
+	}
+	return nil
+}
+
+// Fingerprint returns fingerprint of the first node.
+func (nodes List) Fingerprint() []byte {
+	return nodes[0].fingerprint
+}

--- a/walletnode/services/artworksearch/node/list_test.go
+++ b/walletnode/services/artworksearch/node/list_test.go
@@ -1,0 +1,173 @@
+package node
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pastelnetwork/gonode/walletnode/node/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNodesAdd(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		node *Node
+	}
+	testCases := []struct {
+		nodes List
+		args  args
+		want  List
+	}{
+		{
+			nodes: List{},
+			args:  args{node: &Node{address: "127.0.0.1"}},
+			want: List{
+				&Node{address: "127.0.0.1"},
+			},
+		},
+	}
+
+	for i, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(fmt.Sprintf("testCase-%d", i), func(t *testing.T) {
+			t.Parallel()
+
+			testCase.nodes.Add(testCase.args.node)
+			assert.Equal(t, testCase.want, testCase.nodes)
+		})
+	}
+}
+
+func TestNodesActivate(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		nodes List
+	}{
+		{
+			nodes: List{
+				&Node{address: "127.0.0.1"},
+				&Node{address: "127.0.0.2"},
+			},
+		},
+	}
+
+	for i, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(fmt.Sprintf("testCase-%d", i), func(t *testing.T) {
+			t.Parallel()
+
+			testCase.nodes.Activate()
+			for _, n := range testCase.nodes {
+				assert.True(t, n.activated)
+			}
+		})
+	}
+}
+
+func TestNodesDisconnectInactive(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		nodes List
+		conn  []struct {
+			client       *test.Client
+			activated    bool
+			numberOfCall int
+		}
+	}{
+		{
+			nodes: List{},
+			conn: []struct {
+				client       *test.Client
+				activated    bool
+				numberOfCall int
+			}{
+				{
+					client:       test.NewMockClient(t),
+					numberOfCall: 1,
+					activated:    false,
+				},
+				{
+					client:       test.NewMockClient(t),
+					numberOfCall: 0,
+					activated:    true,
+				},
+			},
+		},
+	}
+
+	for i, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(fmt.Sprintf("testCase-%d", i), func(t *testing.T) {
+			t.Parallel()
+
+			for _, c := range testCase.conn {
+				c.client.ListenOnClose(nil)
+
+				node := &Node{
+					Connection: c.client.Connection,
+					activated:  c.activated,
+				}
+
+				testCase.nodes = append(testCase.nodes, node)
+			}
+
+			testCase.nodes.DisconnectInactive()
+
+			for j, c := range testCase.conn {
+				c := c
+
+				t.Run(fmt.Sprintf("close-called-%d", j), func(t *testing.T) {
+					c.client.AssertCloseCall(c.numberOfCall)
+				})
+
+			}
+
+		})
+	}
+
+}
+
+func TestNodesFindByPastelID(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		id string
+	}
+	testCases := []struct {
+		nodes List
+		args  args
+		want  *Node
+	}{
+		{
+			nodes: List{
+				&Node{pastelID: "1"},
+				&Node{pastelID: "2"},
+			},
+			args: args{"2"},
+			want: &Node{pastelID: "2"},
+		}, {
+			nodes: List{
+				&Node{pastelID: "1"},
+				&Node{pastelID: "2"},
+			},
+			args: args{"3"},
+			want: nil,
+		},
+	}
+
+	for i, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(fmt.Sprintf("testCase-%d", i), func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, testCase.want, testCase.nodes.FindByPastelID(testCase.args.id))
+		})
+	}
+}

--- a/walletnode/services/artworksearch/node/node.go
+++ b/walletnode/services/artworksearch/node/node.go
@@ -1,0 +1,56 @@
+package node
+
+import (
+	"context"
+	"time"
+
+	"github.com/pastelnetwork/gonode/walletnode/node"
+)
+
+// Node represent supernode connection.
+type Node struct {
+	node.Client
+	node.Connection
+
+	activated   bool
+	fingerprint []byte
+
+	address  string
+	pastelID string
+}
+
+func (node *Node) String() string {
+	return node.address
+}
+
+// PastelID returns pastelID
+func (node *Node) PastelID() string {
+	return node.pastelID
+}
+
+// Connect connects to supernode.
+func (node *Node) Connect(ctx context.Context, timeout time.Duration) error {
+	if node.Connection != nil {
+		return nil
+	}
+
+	connCtx, connCancel := context.WithTimeout(ctx, timeout)
+	defer connCancel()
+
+	conn, err := node.Client.Connect(connCtx, node.address)
+	if err != nil {
+		return err
+	}
+	node.Connection = conn
+
+	return nil
+}
+
+// NewNode returns a new Node instance.
+func NewNode(client node.Client, address, pastelID string) *Node {
+	return &Node{
+		Client:   client,
+		address:  address,
+		pastelID: pastelID,
+	}
+}

--- a/walletnode/services/artworksearch/node/node_test.go
+++ b/walletnode/services/artworksearch/node/node_test.go
@@ -28,21 +28,19 @@ func TestNodeConnect(t *testing.T) {
 		assertion                 assert.ErrorAssertionFunc
 	}{
 		{
-			node:                      &Node{address: "127.0.0.1:4444"},
-			address:                   "127.0.0.1:4444",
-			args:                      args{context.Background()},
-			err:                       nil,
-			numberConnectCall:         1,
-			numberRegisterArtWorkCall: 1,
-			assertion:                 assert.NoError,
+			node:              &Node{address: "127.0.0.1:4444"},
+			address:           "127.0.0.1:4444",
+			args:              args{context.Background()},
+			err:               nil,
+			numberConnectCall: 1,
+			assertion:         assert.NoError,
 		}, {
-			node:                      &Node{address: "127.0.0.1:4445"},
-			address:                   "127.0.0.1:4445",
-			args:                      args{context.Background()},
-			err:                       fmt.Errorf("connection timeout"),
-			numberConnectCall:         1,
-			numberRegisterArtWorkCall: 0,
-			assertion:                 assert.Error,
+			node:              &Node{address: "127.0.0.1:4445"},
+			address:           "127.0.0.1:4445",
+			args:              args{context.Background()},
+			err:               fmt.Errorf("connection timeout"),
+			numberConnectCall: 1,
+			assertion:         assert.Error,
 		},
 	}
 
@@ -56,7 +54,7 @@ func TestNodeConnect(t *testing.T) {
 			clientMock := test.NewMockClient(t)
 
 			//listen needed method
-			clientMock.ListenOnConnect("", testCase.err).ListenOnRegisterArtwork()
+			clientMock.ListenOnConnect("", testCase.err)
 
 			//set up node client only
 			testCase.node.Client = clientMock.Client
@@ -66,7 +64,6 @@ func TestNodeConnect(t *testing.T) {
 			//mock assertion
 			clientMock.Client.AssertExpectations(t)
 			clientMock.AssertConnectCall(testCase.numberConnectCall, mock.Anything, testCase.address)
-			clientMock.AssertRegisterArtworkCall(testCase.numberRegisterArtWorkCall)
 		})
 	}
 }

--- a/walletnode/services/artworksearch/service.go
+++ b/walletnode/services/artworksearch/service.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"fmt"
 
-	b58 "github.com/jbenet/go-base58"
 	"github.com/pastelnetwork/gonode/common/errgroup"
 	"github.com/pastelnetwork/gonode/common/service/task"
 	"github.com/pastelnetwork/gonode/p2p"
 	"github.com/pastelnetwork/gonode/pastel"
+	"github.com/pastelnetwork/gonode/walletnode/node"
+	thumbnail "github.com/pastelnetwork/gonode/walletnode/services/artworksearch/thumbnail"
 )
 
 const (
@@ -20,6 +21,8 @@ type Service struct {
 	*task.Worker
 	p2pClient    p2p.Client
 	pastelClient pastel.Client
+	nodeClient   node.Client
+	config       *Config
 }
 
 // Run starts worker.
@@ -56,20 +59,14 @@ func (service *Service) AddTask(request *ArtSearchRequest) string {
 }
 
 // NewService returns a new Service instance.
-func NewService(pastelClient pastel.Client, p2pClient p2p.Client) *Service {
+func NewService(config *Config, pastelClient pastel.Client, p2pClient p2p.Client, nodeClient node.Client) *Service {
 	return &Service{
+		config:       config,
 		pastelClient: pastelClient,
 		p2pClient:    p2pClient,
 		Worker:       task.NewWorker(),
+		nodeClient:   nodeClient,
 	}
-}
-
-// FetchThumbnail gets artwork thumbnail
-func (service *Service) FetchThumbnail(ctx context.Context, res *pastel.RegTicket) (data []byte, err error) {
-	hash := res.RegTicketData.ArtTicketData.AppTicketData.ThumbnailHash
-	key := b58.Encode(hash)
-
-	return service.p2pClient.Retrieve(ctx, key)
 }
 
 // RegTicket pull art registration ticket from cNode & decodes base64 encoded fields
@@ -90,4 +87,16 @@ func (service *Service) RegTicket(ctx context.Context, RegTXID string) (*pastel.
 	}
 
 	return &regTicket, nil
+}
+
+// GetThumbnail gets thumbnail
+func (service *Service) GetThumbnail(ctx context.Context, regTicket *pastel.RegTicket) (data []byte, err error) {
+	thumbnailHelper := thumbnail.New(service.pastelClient, service.nodeClient, service.config.ConnectTimeout)
+
+	if err := thumbnailHelper.Connect(ctx, 1); err != nil {
+		return data, fmt.Errorf("connect Thumbnail helper : %s", err)
+	}
+	defer thumbnailHelper.Close()
+
+	return thumbnailHelper.Fetch(ctx, string(regTicket.RegTicketData.ArtTicketData.AppTicketData.ThumbnailHash))
 }

--- a/walletnode/services/artworksearch/service_test.go
+++ b/walletnode/services/artworksearch/service_test.go
@@ -1,0 +1,188 @@
+package artworksearch
+
+import (
+	"context"
+	b64 "encoding/base64"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/pastelnetwork/gonode/pastel"
+	pastelMock "github.com/pastelnetwork/gonode/pastel/test"
+	nodeMock "github.com/pastelnetwork/gonode/walletnode/node/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRegTicket(t *testing.T) {
+	testIDA := "test-id-a"
+	testIDB := "test-id-b"
+
+	t.Parallel()
+
+	regTicketA := pastel.RegTicket{
+		TXID: testIDA,
+		RegTicketData: pastel.RegTicketData{
+			ArtTicketData: pastel.ArtTicket{
+				AppTicketData: pastel.AppTicket{
+					AuthorPastelID: "author-id",
+					ArtistName:     "Alan Majchrowicz",
+				},
+			},
+		},
+	}
+
+	regTicketB := pastel.RegTicket{
+		TXID: testIDB,
+		RegTicketData: pastel.RegTicketData{
+			ArtTicketData: pastel.ArtTicket{
+				AppTicketData: pastel.AppTicket{
+					AuthorPastelID: "author-id-b",
+					ArtistName:     "Andy",
+					ArtworkTitle:   "alantic",
+				},
+			},
+		},
+	}
+
+	assignBase64strs(t, &regTicketA)
+	assignBase64strs(t, &regTicketB)
+
+	nodes := pastel.MasterNodes{}
+	for i := 0; i < 10; i++ {
+		nodes = append(nodes, pastel.MasterNode{})
+	}
+
+	type args struct {
+		regTicketID  string
+		regTicketErr error
+	}
+
+	testCases := map[string]struct {
+		args args
+		want pastel.RegTicket
+		err  error
+	}{
+		"simple-a": {
+			args: args{
+				regTicketID: testIDA,
+			},
+			want: regTicketA,
+			err:  nil,
+		},
+		"simple-b": {
+			args: args{
+				regTicketID: testIDB,
+			},
+			want: regTicketB,
+			err:  nil,
+		},
+	}
+
+	ctx := context.Background()
+	for name, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(fmt.Sprintf("testCase- %v", name), func(t *testing.T) {
+			t.Parallel()
+
+			pastelClientMock := pastelMock.NewMockClient(t)
+			pastelClientMock.ListenOnMasterNodesTop(nodes, nil)
+
+			nodeClientMock := nodeMock.NewMockClient(t)
+			nodeClientMock.ListenOnConnect(nil).ListenOnRegisterArtwork().ListenOnClose(nil)
+
+			pastelClientMock.ListenOnRegTicket(testCase.args.regTicketID, testCase.want, testCase.args.regTicketErr)
+
+			service := NewService(NewConfig(), pastelClientMock, nil, nodeClientMock)
+
+			result, err := service.RegTicket(ctx, testCase.args.regTicketID)
+			assert.Equal(t, testCase.err, err)
+			assert.Equal(t, testCase.want.TXID, result.TXID)
+			assert.Equal(t, testCase.want.RegTicketData.ArtTicketData.Author,
+				result.RegTicketData.ArtTicketData.Author)
+		})
+	}
+}
+
+func TestGetThumbnail(t *testing.T) {
+	t.Parallel()
+
+	regTicketA := pastel.RegTicket{
+		TXID: "test-id-a",
+		RegTicketData: pastel.RegTicketData{
+			ArtTicketData: pastel.ArtTicket{
+				AppTicketData: pastel.AppTicket{
+					AuthorPastelID: "author-id",
+					ArtistName:     "Alan Majchrowicz",
+				},
+			},
+		},
+	}
+
+	nodes := pastel.MasterNodes{}
+	for i := 0; i < 10; i++ {
+		nodes = append(nodes, pastel.MasterNode{})
+	}
+
+	type args struct {
+		regTicket *pastel.RegTicket
+	}
+
+	testCases := map[string]struct {
+		args args
+		want []byte
+	}{
+		"simple-a": {
+			args: args{
+				regTicket: &regTicketA,
+			},
+			want: []byte{},
+		},
+		"simple-b": {
+			args: args{
+				regTicket: &regTicketA,
+			},
+			want: []byte{},
+		},
+	}
+
+	ctx := context.Background()
+	for name, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(fmt.Sprintf("testCase- %v", name), func(t *testing.T) {
+			t.Parallel()
+
+			pastelClientMock := pastelMock.NewMockClient(t)
+			pastelClientMock.ListenOnMasterNodesTop(nodes, nil)
+
+			nodeClientMock := nodeMock.NewMockClient(t)
+			nodeClientMock.ListenOnConnect(nil).ListenOnRegisterArtwork().ListenOnClose(nil)
+
+			service := &Service{
+				pastelClient: pastelClientMock.Client,
+				nodeClient:   nodeClientMock,
+				config:       NewConfig(),
+			}
+
+			result, err := service.GetThumbnail(ctx, testCase.args.regTicket)
+			assert.Nil(t, err)
+			assert.Equal(t, testCase.want, result)
+		})
+	}
+}
+
+func assignBase64strs(t *testing.T, ticket *pastel.RegTicket) {
+	toBase64 := func(from interface{}) ([]byte, error) {
+		testBytes, err := json.Marshal(from)
+		return []byte(b64.StdEncoding.EncodeToString([]byte(testBytes))), err
+	}
+
+	base64Bytes, err := toBase64(ticket.RegTicketData.ArtTicketData.AppTicketData)
+	assert.Nil(t, err)
+	ticket.RegTicketData.ArtTicketData.AppTicket = base64Bytes
+
+	base64Bytes, err = toBase64(ticket.RegTicketData.ArtTicketData)
+	assert.Nil(t, err)
+	ticket.RegTicketData.ArtTicket = base64Bytes
+}

--- a/walletnode/services/artworksearch/service_test.go
+++ b/walletnode/services/artworksearch/service_test.go
@@ -89,7 +89,7 @@ func TestRegTicket(t *testing.T) {
 			pastelClientMock.ListenOnMasterNodesTop(nodes, nil)
 
 			nodeClientMock := nodeMock.NewMockClient(t)
-			nodeClientMock.ListenOnConnect(nil).ListenOnRegisterArtwork().ListenOnClose(nil)
+			nodeClientMock.ListenOnConnect("", nil).ListenOnRegisterArtwork().ListenOnClose(nil)
 
 			pastelClientMock.ListenOnRegTicket(testCase.args.regTicketID, testCase.want, testCase.args.regTicketErr)
 
@@ -157,7 +157,7 @@ func TestGetThumbnail(t *testing.T) {
 			pastelClientMock.ListenOnMasterNodesTop(nodes, nil)
 
 			nodeClientMock := nodeMock.NewMockClient(t)
-			nodeClientMock.ListenOnConnect(nil).ListenOnRegisterArtwork().ListenOnClose(nil)
+			nodeClientMock.ListenOnConnect("", nil).ListenOnRegisterArtwork().ListenOnClose(nil)
 
 			service := &Service{
 				pastelClient: pastelClientMock.Client,

--- a/walletnode/services/artworksearch/task.go
+++ b/walletnode/services/artworksearch/task.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pastelnetwork/gonode/common/log"
 	"github.com/pastelnetwork/gonode/common/service/task"
 	"github.com/pastelnetwork/gonode/pastel"
+	"github.com/pastelnetwork/gonode/walletnode/services/artworksearch/thumbnail"
 )
 
 // Task is the task of searching for artwork.
@@ -21,9 +22,10 @@ type Task struct {
 	searchResult   []*RegTicketSearch
 	searchResMutex sync.Mutex
 
-	resultChan chan *RegTicketSearch
-	err        error
-	request    *ArtSearchRequest
+	resultChan      chan *RegTicketSearch
+	err             error
+	request         *ArtSearchRequest
+	thumbnailHelper thumbnail.Helper
 }
 
 // Run starts the task
@@ -33,6 +35,7 @@ func (task *Task) Run(ctx context.Context) error {
 	log.WithContext(ctx).Debugf("Start task")
 	defer log.WithContext(ctx).Debugf("End task")
 	defer close(task.resultChan)
+	defer task.thumbnailHelper.Close()
 
 	if err := task.run(ctx); err != nil {
 		task.err = err
@@ -48,15 +51,12 @@ func (task *Task) Run(ctx context.Context) error {
 }
 
 func (task *Task) run(ctx context.Context) error {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	actTickets, err := task.pastelClient.ActTickets(ctx, pastel.ActTicketAll, task.request.MinBlock)
 	if err != nil {
 		return fmt.Errorf("act ticket: %s", err)
 	}
 
-	group, ctx := errgroup.WithContext(ctx)
+	group, gctx := errgroup.WithContext(ctx)
 
 	for _, ticket := range actTickets {
 		ticket := ticket
@@ -70,7 +70,7 @@ func (task *Task) run(ctx context.Context) error {
 		}
 
 		group.Go(func() error {
-			regTicket, err := task.RegTicket(ctx, ticket.ActTicketData.RegTXID)
+			regTicket, err := task.RegTicket(gctx, ticket.ActTicketData.RegTXID)
 			if err != nil {
 				log.WithContext(ctx).WithField("txid", ticket.TXID).WithError(err).Error("Reg Ticket")
 
@@ -97,20 +97,27 @@ func (task *Task) run(ctx context.Context) error {
 		task.searchResult = task.searchResult[:task.request.Limit]
 	}
 
-	group, ctx = errgroup.WithContext(ctx)
+	pastelConnections := 10
+	if len(task.searchResult) < pastelConnections {
+		pastelConnections = len(task.searchResult)
+	}
+
+	if err := task.thumbnailHelper.Connect(ctx, uint(pastelConnections)); err != nil {
+		return fmt.Errorf("connect Thumbnail helper : %s", err)
+	}
+
+	group, gctx = errgroup.WithContext(ctx)
 	for i, res := range task.searchResult {
 		res := res
 		res.MatchIndex = i
 
 		group.Go(func() error {
-
-			data, err := task.FetchThumbnail(ctx, res.RegTicket)
+			data, err := task.thumbnailHelper.Fetch(gctx, string(res.RegTicket.RegTicketData.ArtTicketData.AppTicketData.ThumbnailHash))
 			if err != nil {
 				log.WithContext(ctx).WithField("txid", res.TXID).WithError(err).Error("Fetch Thumbnail")
 
-				return fmt.Errorf("txid: %s - err: %s", res.TXID, err)
+				return fmt.Errorf("fetch thumbnail: txid: %s - err: %s", res.TXID, err)
 			}
-
 			res.Thumbnail = data
 
 			// Post on result channel
@@ -171,9 +178,10 @@ func (task *Task) SubscribeSearchResult() <-chan *RegTicketSearch {
 // NewTask returns a new Task instance.
 func NewTask(service *Service, request *ArtSearchRequest) *Task {
 	return &Task{
-		Task:       task.New(StatusTaskStarted),
-		Service:    service,
-		request:    request,
-		resultChan: make(chan *RegTicketSearch),
+		Task:            task.New(StatusTaskStarted),
+		Service:         service,
+		request:         request,
+		resultChan:      make(chan *RegTicketSearch),
+		thumbnailHelper: thumbnail.New(service.pastelClient, service.nodeClient, service.config.ConnectTimeout),
 	}
 }

--- a/walletnode/services/artworksearch/task_test.go
+++ b/walletnode/services/artworksearch/task_test.go
@@ -159,7 +159,7 @@ func TestRunTask(t *testing.T) {
 			pastelClientMock.ListenOnMasterNodesTop(nodes, nil)
 
 			nodeClientMock := nodeMock.NewMockClient(t)
-			nodeClientMock.ListenOnConnect(nil).ListenOnRegisterArtwork().ListenOnClose(nil)
+			nodeClientMock.ListenOnConnect("", nil).ListenOnRegisterArtwork().ListenOnClose(nil)
 
 			if len(testCase.args.actTickets) != len(testCase.args.regTickets) {
 				t.Fatalf("#act_tickets != # reg_tickets")

--- a/walletnode/services/artworksearch/thumbnail/thumbnail.go
+++ b/walletnode/services/artworksearch/thumbnail/thumbnail.go
@@ -1,0 +1,163 @@
+package thumbnail
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/pastelnetwork/gonode/common/log"
+	"github.com/pastelnetwork/gonode/pastel"
+	nodeClient "github.com/pastelnetwork/gonode/walletnode/node"
+	"github.com/pastelnetwork/gonode/walletnode/services/artworkregister/node"
+)
+
+const (
+	maxConnections    = 10
+	maxConnectionsErr = "cannot connect to more than 10 nodes"
+)
+
+// Helper is interface contract for Thumbnail Getter
+type Helper interface {
+	Connect(ctx context.Context, connections uint) error
+	Fetch(ctx context.Context, key string) ([]byte, error)
+	Close()
+}
+
+type thumbnailHelper struct {
+	pastelClient pastel.Client
+	nodeClient   nodeClient.Client
+
+	reqCh      chan request
+	timeOut    time.Duration
+	isClosed   bool
+	closeMutex sync.Mutex
+}
+
+// New returns a new instance of thumbnailHelper as Helper
+func New(pastelClient pastel.Client, nodeClient nodeClient.Client, timeout time.Duration) Helper {
+	return &thumbnailHelper{
+		pastelClient: pastelClient,
+		nodeClient:   nodeClient,
+		timeOut:      timeout,
+		reqCh:        make(chan request),
+	}
+}
+
+type response struct {
+	data []byte
+	err  error
+}
+
+type request struct {
+	key    string
+	respCh chan *response
+}
+
+// Connect creates `conncetions` no. of connections with supernode & starts thumbnail request listeners
+func (t *thumbnailHelper) Connect(ctx context.Context, connections uint) error {
+	if connections > maxConnections {
+		return errors.New(maxConnectionsErr)
+	}
+
+	nodes, err := t.pastelTopNodes(ctx, connections)
+	if err != nil {
+		return fmt.Errorf("pastelTopNodes: %v", err)
+	}
+
+	for _, node := range nodes {
+		node := node
+		if err := node.Connect(ctx, t.timeOut); err != nil {
+			return err
+		}
+
+		go func() {
+			t.listen(ctx, node)
+			t.Close()
+			if err := node.Connection.Close(); err != nil {
+				log.WithContext(ctx).WithError(err).Error("ThumbnailPuller.Start-Close node connection")
+			}
+		}()
+	}
+
+	return nil
+}
+
+func (t *thumbnailHelper) listen(ctx context.Context, n *node.Node) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case req, ok := <-t.reqCh:
+			if !ok {
+				return
+			}
+
+			// TODO: get thumbnail from supernode using Node
+			// hard-coding fetched thumbnail for dev purposes
+			fmt.Println("thumb-key:", req.key, n.PastelID())
+			thumb := []byte{}
+			resp := &response{data: thumb}
+			req.respCh <- resp
+		}
+	}
+}
+
+// Fetch gets thumbnail
+func (t *thumbnailHelper) Fetch(ctx context.Context, key string) (data []byte, err error) {
+	if t.IsClosed() {
+		return data, errors.New("connection is closed")
+	}
+
+	respCh := make(chan *response)
+	req := request{key: key, respCh: respCh}
+
+	go func() {
+		t.reqCh <- req
+	}()
+
+	select {
+	case <-ctx.Done():
+		return data, nil
+	case resp := <-respCh:
+		return resp.data, resp.err
+	}
+}
+
+func (t *thumbnailHelper) pastelTopNodes(ctx context.Context, connections uint) (nodes node.List, err error) {
+	mns, err := t.pastelClient.MasterNodesTop(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for i, mn := range mns {
+		if uint(i) == connections {
+			break
+		}
+
+		nodes = append(nodes, node.NewNode(t.nodeClient, mn.ExtAddress, mn.ExtKey))
+	}
+
+	return nodes, nil
+}
+
+// Close closes request channel. Once Close is called, the helper can no longer fetch thumbnails
+func (t *thumbnailHelper) Close() {
+	if t.isClosed {
+		return
+	}
+
+	t.closeMutex.Lock()
+	defer t.closeMutex.Unlock()
+
+	t.isClosed = true
+	close(t.reqCh)
+}
+
+// IsClosed returns whether helper is closed
+func (t *thumbnailHelper) IsClosed() bool {
+	t.closeMutex.Lock()
+	defer t.closeMutex.Unlock()
+
+	return t.isClosed
+}

--- a/walletnode/services/artworksearch/thumbnail/thumbnail.go
+++ b/walletnode/services/artworksearch/thumbnail/thumbnail.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pastelnetwork/gonode/common/log"
 	"github.com/pastelnetwork/gonode/pastel"
 	nodeClient "github.com/pastelnetwork/gonode/walletnode/node"
-	"github.com/pastelnetwork/gonode/walletnode/services/artworkregister/node"
+	"github.com/pastelnetwork/gonode/walletnode/services/artworksearch/node"
 )
 
 const (
@@ -69,6 +69,8 @@ func (t *thumbnailHelper) Connect(ctx context.Context, connections uint) error {
 	for _, node := range nodes {
 		node := node
 		if err := node.Connect(ctx, t.timeOut); err != nil {
+			t.Close()
+
 			return err
 		}
 
@@ -143,12 +145,12 @@ func (t *thumbnailHelper) pastelTopNodes(ctx context.Context, connections uint) 
 
 // Close closes request channel. Once Close is called, the helper can no longer fetch thumbnails
 func (t *thumbnailHelper) Close() {
+	t.closeMutex.Lock()
+	defer t.closeMutex.Unlock()
+
 	if t.isClosed {
 		return
 	}
-
-	t.closeMutex.Lock()
-	defer t.closeMutex.Unlock()
 
 	t.isClosed = true
 	close(t.reqCh)

--- a/walletnode/services/artworksearch/thumbnail/thumbnail_test.go
+++ b/walletnode/services/artworksearch/thumbnail/thumbnail_test.go
@@ -3,6 +3,7 @@ package thumbnail
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -17,25 +18,22 @@ func TestConnect(t *testing.T) {
 	t.Parallel()
 	nodes := pastel.MasterNodes{}
 	for i := 0; i < 10; i++ {
-		nodes = append(nodes, pastel.MasterNode{})
+		nodes = append(nodes, pastel.MasterNode{ExtAddress: fmt.Sprint(i)})
 	}
 
 	pastelClientMock := pastelMock.NewMockClient(t)
 	pastelClientMock.ListenOnMasterNodesTop(nodes, nil)
 
-	nodeClientMock := nodeMock.NewMockClient(t)
-	nodeClientMock.ListenOnConnect(nil).ListenOnRegisterArtwork().ListenOnClose(nil)
-
-	helper := New(pastelClientMock, nodeClientMock, 2*time.Second)
-
 	tests := map[string]struct {
 		helper      Helper
 		connections uint
+		nodeErr     error
 		err         error
 	}{
-		"one":           {helper: helper, connections: 1, err: nil},
-		"max":           {helper: helper, connections: 10, err: nil},
-		"more-than-max": {helper: helper, connections: maxConnections + 1, err: errors.New(maxConnectionsErr)},
+		"one":              {connections: 1, err: nil},
+		"max":              {connections: 10, err: nil},
+		"more-than-max":    {connections: maxConnections + 1, err: errors.New(maxConnectionsErr)},
+		"node-connect-err": {connections: 4, nodeErr: errors.New("test"), err: errors.New("test")},
 	}
 
 	for name, tc := range tests {
@@ -43,8 +41,23 @@ func TestConnect(t *testing.T) {
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			err := tc.helper.Connect(context.Background(), tc.connections)
+
+			nodeClientMock := nodeMock.NewMockClient(t)
+			if tc.nodeErr == nil {
+				nodeClientMock.ListenOnConnect("", nil)
+			} else {
+				nodeClientMock.ListenOnConnect("0", nil)
+				nodeClientMock.ListenOnConnect("1", nil)
+				nodeClientMock.ListenOnConnect("2", nil)
+				nodeClientMock.ListenOnConnect("3", tc.nodeErr)
+			}
+			nodeClientMock.ListenOnClose(nil)
+
+			helper := New(pastelClientMock, nodeClientMock, 2*time.Second)
+
+			err := helper.Connect(context.Background(), tc.connections)
 			assert.Equal(t, tc.err, err)
+			helper.Close()
 		})
 	}
 }
@@ -60,7 +73,7 @@ func TestFetch(t *testing.T) {
 	pastelClientMock.ListenOnMasterNodesTop(nodes, nil)
 
 	nodeClientMock := nodeMock.NewMockClient(t)
-	nodeClientMock.ListenOnConnect(nil).ListenOnRegisterArtwork().ListenOnClose(nil)
+	nodeClientMock.ListenOnConnect("", nil).ListenOnRegisterArtwork().ListenOnClose(nil)
 
 	helper := New(pastelClientMock, nodeClientMock, 2*time.Second)
 

--- a/walletnode/services/artworksearch/thumbnail/thumbnail_test.go
+++ b/walletnode/services/artworksearch/thumbnail/thumbnail_test.go
@@ -1,0 +1,90 @@
+package thumbnail
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/pastelnetwork/gonode/pastel"
+
+	pastelMock "github.com/pastelnetwork/gonode/pastel/test"
+	nodeMock "github.com/pastelnetwork/gonode/walletnode/node/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConnect(t *testing.T) {
+	t.Parallel()
+	nodes := pastel.MasterNodes{}
+	for i := 0; i < 10; i++ {
+		nodes = append(nodes, pastel.MasterNode{})
+	}
+
+	pastelClientMock := pastelMock.NewMockClient(t)
+	pastelClientMock.ListenOnMasterNodesTop(nodes, nil)
+
+	nodeClientMock := nodeMock.NewMockClient(t)
+	nodeClientMock.ListenOnConnect(nil).ListenOnRegisterArtwork().ListenOnClose(nil)
+
+	helper := New(pastelClientMock, nodeClientMock, 2*time.Second)
+
+	tests := map[string]struct {
+		helper      Helper
+		connections uint
+		err         error
+	}{
+		"one":           {helper: helper, connections: 1, err: nil},
+		"max":           {helper: helper, connections: 10, err: nil},
+		"more-than-max": {helper: helper, connections: maxConnections + 1, err: errors.New(maxConnectionsErr)},
+	}
+
+	for name, tc := range tests {
+		tc := tc
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			err := tc.helper.Connect(context.Background(), tc.connections)
+			assert.Equal(t, tc.err, err)
+		})
+	}
+}
+
+func TestFetch(t *testing.T) {
+	t.Parallel()
+	nodes := pastel.MasterNodes{}
+	for i := 0; i < 10; i++ {
+		nodes = append(nodes, pastel.MasterNode{})
+	}
+
+	pastelClientMock := pastelMock.NewMockClient(t)
+	pastelClientMock.ListenOnMasterNodesTop(nodes, nil)
+
+	nodeClientMock := nodeMock.NewMockClient(t)
+	nodeClientMock.ListenOnConnect(nil).ListenOnRegisterArtwork().ListenOnClose(nil)
+
+	helper := New(pastelClientMock, nodeClientMock, 2*time.Second)
+
+	tests := map[string]struct {
+		helper      Helper
+		connections uint
+		err         error
+	}{
+		"one-node":  {helper: helper, connections: 1, err: nil},
+		"max-nodes": {helper: helper, connections: 10, err: nil},
+	}
+
+	for name, tc := range tests {
+		tc := tc
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			err := tc.helper.Connect(ctx, tc.connections)
+			assert.Nil(t, err)
+
+			_, err = tc.helper.Fetch(ctx, "key")
+			assert.Nil(t, err)
+		})
+	}
+}

--- a/walletnode/services/common/config.go
+++ b/walletnode/services/common/config.go
@@ -1,10 +1,19 @@
 package common
 
+import "time"
+
+const (
+	connectTimeout = time.Second * 2
+)
+
 // Config contains common configuration of the servcies.
 type Config struct {
+	ConnectTimeout time.Duration
 }
 
 // NewConfig returns a new Config instance
 func NewConfig() *Config {
-	return &Config{}
+	return &Config{
+		ConnectTimeout: connectTimeout,
+	}
 }


### PR DESCRIPTION
- add code infra to spawn 10 connections with supernode & fetch thumbnails in parallel and return result back to the caller as soon as a thumbnail is received.
- added unit test cases of this new code infra & refactored previously existing tests to cope up with new changes - coverage of artsearch package now 80.5 % 
- This requires THumbnail API which is under progress under a different [PR](https://github.com/pastelnetwork/gonode/pull/105)
 So right now a place holder is added until that API is available. 