### PR TITLE
Update structure of Art Reg ticket with new rareness scores.

### DIFF
--- a/pastel/reg_ticket.go
+++ b/pastel/reg_ticket.go
@@ -89,6 +89,7 @@ type AppTicket struct {
 	InternetRarenessScore   float64             `json:"internet_rareness_score"`
 	OpenNSFWScore           float64             `json:"open_nsfw_score"`
 	AlternateNSFWScores     AlternateNSFWScores `json:"alternate_nsfw_scores"`
+	ImageHashes             ImageHashes         `json:"image_hashes"`
 
 	RQIDs []string `json:"rq_ids"`
 	RQOti []byte   `json:"rq_oti"`
@@ -101,6 +102,13 @@ type AlternateNSFWScores struct {
 	Neutral  float64 `json:"neutral"`
 	Porn     float64 `json:"porn"`
 	Sexy     float64 `json:"sexy"`
+}
+
+// ImageHashes represents image hashes from dupe detection service
+type ImageHashes struct {
+	PerceptualHash string `json:"perceptual_hash"`
+	AverageHash    string `json:"average_hash"`
+	DifferenceHash string `json:"difference_hash"`
 }
 
 // TicketSignatures represents signatures from parties

--- a/pastel/reg_ticket.go
+++ b/pastel/reg_ticket.go
@@ -1,5 +1,13 @@
 package pastel
 
+import (
+	"encoding/json"
+
+	"github.com/pastelnetwork/gonode/common/errors"
+)
+
+// Refer https://pastel.wiki/en/Architecture/Components/TicketStructures
+
 // RegTickets is a collection of RegTicket
 type RegTickets []RegTicket
 
@@ -12,29 +20,39 @@ type RegTicket struct {
 
 // RegTicketData is Pastel Registration ticket structure
 type RegTicketData struct {
-	Type          string    `json:"type"`
-	ArtistHeight  int       `json:"artist_height"`
-	Key1          string    `json:"key1"`
-	Key2          string    `json:"key2"`
-	IsGreen       bool      `json:"is_green"`
-	StorageFee    int       `json:"storage_fee"`
-	TotalCopes    int       `json:"total_copes"`
-	Royalty       int       `json:"royalty"`
-	Version       int       `json:"version"`
-	ArtTicket     []byte    `json:"art_ticket"`
-	ArtTicketData ArtTicket `json:"-"`
+	Type          string           `json:"type"`
+	ArtistHeight  int              `json:"artist_height"`
+	Signatures    TicketSignatures `json:"signatures"`
+	Key1          string           `json:"key1"`
+	Key2          string           `json:"key2"`
+	IsGreen       bool             `json:"is_green"`
+	StorageFee    int              `json:"storage_fee"`
+	TotalCopies   int              `json:"total_copies"`
+	Royalty       int              `json:"royalty"`
+	Version       int              `json:"version"`
+	ArtTicket     []byte           `json:"art_ticket"`
+	ArtTicketData ArtTicket        `json:"-"`
 }
 
 // ArtTicket is Pastel Art Ticket
 type ArtTicket struct {
 	Version       int       `json:"version"`
-	Blocknum      int       `json:"blocknum"`
 	Author        []byte    `json:"author"`
-	DataHash      []byte    `json:"data_hash"`
+	BlockNum      int       `json:"blocknum"`
+	BlockHash     []byte    `json:"block_hash"`
 	Copies        int       `json:"copies"`
-	Reserved      []byte    `json:"reserved"`
+	Royalty       int       `json:"royalty"`
+	Green         string    `json:"green_address"`
 	AppTicket     []byte    `json:"app_ticket"`
 	AppTicketData AppTicket `json:"-"`
+}
+
+// FingerAndScores represents structure of app ticket
+type FingerAndScores struct {
+	FingerprintData []byte
+	RarenessScore   int
+	NSFWScore       int
+	SeenScore       int
 }
 
 // AppTicket represents pastel App ticket.
@@ -42,7 +60,6 @@ type AppTicket struct {
 	AuthorPastelID string `json:"author_pastel_id"`
 	BlockTxID      string `json:"block_tx_id"`
 	BlockNum       int    `json:"block_num"`
-	ImageHash      string `json:"image_hash"`
 
 	ArtistName             string `json:"artist_name"`
 	ArtistWebsite          string `json:"artist_website"`
@@ -54,18 +71,147 @@ type AppTicket struct {
 	ArtworkKeywordSet              string `json:"artwork_keyword_set"`
 	TotalCopies                    int    `json:"total_copies"`
 
-	ThumbnailHash []byte `json:"thumbnail_hash"`
-	DataHash      []byte `json:"data_hash"`
+	PreviewHash    []byte `json:"preview_hash"`
+	Thumbnail1Hash []byte `json:"thumbnail1_hash"`
+	Thumbnail2Hash []byte `json:"thumbnail2_hash"`
 
-	Fingerprints          []byte `json:"fingerprints"`
-	FingerprintsHash      []byte `json:"fingerprints_hash"`
-	FingerprintsSignature []byte `json:"fingerprints_signature"`
+	DataHash []byte `json:"data_hash"`
 
-	RarenessScore int `json:"rareness_score"`
-	NSFWScore     int `json:"nsfw_score"`
-	SeenScore     int `json:"seen_score"`
+	Fingerprints          []float64 `json:"fingerprints"`
+	FingerprintsHash      []byte    `json:"fingerprints_hash"`
+	FingerprintsSignature []byte    `json:"fingerprints_signature"`
 
-	RQIDs   []string `json:"rq_ids"`
-	RQCoti  int64    `json:"rq_coti"`
-	RQSsoti int64    `json:"rq_ssoti"`
+	DupeDetectionSystemVer  string              `json:"dupe_detection_system_version"`
+	MatchesFoundOnFirstPage int                 `json:"matches_found_on_first_page"`
+	NumberOfResultPages     int                 `json:"number_of_pages_of_results"`
+	FirstMatchURL           string              `json:"url_of_first_match_in_page"`
+	PastelRarenessScore     float64             `json:"pastel_rareness_score"`
+	InternetRarenessScore   float64             `json:"internet_rareness_score"`
+	OpenNSFWScore           float64             `json:"open_nsfw_score"`
+	AlternateNSFWScores     AlternateNSFWScores `json:"alternate_nsfw_scores"`
+
+	RQIDs []string `json:"rq_ids"`
+	RQOti []byte   `json:"rq_oti"`
+}
+
+// AlternateNSFWScores represents alternate NSFW scores from dupe detection service
+type AlternateNSFWScores struct {
+	Drawings float64 `json:"drawings"`
+	Hentai   float64 `json:"hentai"`
+	Neutral  float64 `json:"neutral"`
+	Porn     float64 `json:"porn"`
+	Sexy     float64 `json:"sexy"`
+}
+
+// TicketSignatures represents signatures from parties
+type TicketSignatures struct {
+	Artist map[string]string `json:"artist,omitempty"`
+	Mn1    map[string]string `json:"mn1,omitempty"`
+	Mn2    map[string]string `json:"mn2,omitempty"`
+	Mn3    map[string]string `json:"mn3,omitempty"`
+}
+
+// RegisterArtRequest represents request to register an art
+// "ticket" "{signatures}" "jXYqZNPj21RVnwxnEJ654wEdzi7GZTZ5LAdiotBmPrF7pDMkpX1JegDMQZX55WZLkvy9fxNpZcbBJuE8QYUqBF" "passphrase", "key1", "key2", 100)")
+type RegisterArtRequest struct {
+	Ticket      *ArtTicket
+	Signatures  *TicketSignatures
+	Mn1PastelID string
+	Pasphase    string
+	Key1        string
+	Key2        string
+	Fee         int64
+}
+
+// GetRegisterArtFeeRequest represents a request to get registration fee
+type GetRegisterArtFeeRequest struct {
+	Ticket      *ArtTicket
+	Signatures  *TicketSignatures
+	Mn1PastelID string
+	Passphrase  string
+	Key1        string
+	Key2        string
+	Fee         int64
+	ImgSizeInMb int64
+}
+
+type internalArtTicket struct {
+	Version   int    `json:"version"`
+	Author    []byte `json:"author"`
+	BlockNum  int    `json:"blocknum"`
+	BlockHash []byte `json:"block_hash"`
+	Copies    int    `json:"copies"`
+	Royalty   int    `json:"royalty"`
+	Green     string `json:"green_address"`
+	AppTicket []byte `json:"app_ticket"`
+}
+
+// EncodeArtTicket encodes  ArtTicket into byte array
+func EncodeArtTicket(ticket *ArtTicket) ([]byte, error) {
+	appTicket, err := json.Marshal(ticket.AppTicketData)
+	if err != nil {
+		return nil, errors.Errorf("failed to marshal app ticket data: %w", err)
+	}
+
+	// ArtTicket is Pastel Art Ticket
+	artTicket := internalArtTicket{
+		Version:   ticket.Version,
+		Author:    ticket.Author,
+		BlockNum:  ticket.BlockNum,
+		BlockHash: ticket.BlockHash,
+		Copies:    ticket.Copies,
+		Royalty:   ticket.Royalty,
+		Green:     ticket.Green,
+		AppTicket: appTicket,
+	}
+
+	b, err := json.Marshal(artTicket)
+	if err != nil {
+		return nil, errors.Errorf("failed to marshal art ticket: %w", err)
+	}
+
+	return b, nil
+}
+
+// DecodeArtTicket decoded byte array into ArtTicket
+func DecodeArtTicket(b []byte) (*ArtTicket, error) {
+	res := internalArtTicket{}
+	err := json.Unmarshal(b, &res)
+
+	if err != nil {
+		return nil, errors.Errorf("failed to unmarshal art ticket: %w", err)
+	}
+
+	appTicket := AppTicket{}
+
+	err = json.Unmarshal(res.AppTicket, &appTicket)
+	if err != nil {
+		return nil, errors.Errorf("failed to unmarshal app ticket data: %w", err)
+	}
+
+	return &ArtTicket{
+		Version:       res.Version,
+		Author:        res.Author,
+		BlockNum:      res.BlockNum,
+		BlockHash:     res.BlockHash,
+		Copies:        res.Copies,
+		Royalty:       res.Royalty,
+		Green:         res.Green,
+		AppTicketData: appTicket,
+	}, nil
+
+}
+
+// EncodeSignatures encodes TicketSignatures into byte array
+func EncodeSignatures(signatures TicketSignatures) ([]byte, error) {
+	// reset signatures of Mn1 if any
+	signatures.Mn1 = nil
+
+	b, err := json.Marshal(signatures)
+
+	if err != nil {
+		return nil, errors.Errorf("failed to marshal signatures: %w", err)
+	}
+
+	return b, nil
 }

--- a/walletnode/api/services/helper.go
+++ b/walletnode/api/services/helper.go
@@ -127,10 +127,11 @@ func toArtworkDetail(ticket *pastel.RegTicket) *artworks.ArtworkDetail {
 		SeriesName:       &ticket.RegTicketData.ArtTicketData.AppTicketData.ArtworkSeriesName,
 		IsGreen:          ticket.RegTicketData.IsGreen,
 		Royalty:          float64(ticket.RegTicketData.Royalty),
-		RarenessScore:    ticket.RegTicketData.ArtTicketData.AppTicketData.RarenessScore,
-		NsfwScore:        ticket.RegTicketData.ArtTicketData.AppTicketData.NSFWScore,
-		SeenScore:        ticket.RegTicketData.ArtTicketData.AppTicketData.SeenScore,
-		Version:          &ticket.RegTicketData.ArtTicketData.Version,
-		StorageFee:       &ticket.RegTicketData.StorageFee,
+		// FIXME
+		// RarenessScore:    ticket.RegTicketData.ArtTicketData.AppTicketData.RarenessScore,
+		// NsfwScore:        ticket.RegTicketData.ArtTicketData.AppTicketData.NSFWScore,
+		// SeenScore:        ticket.RegTicketData.ArtTicketData.AppTicketData.SeenScore,
+		Version:    &ticket.RegTicketData.ArtTicketData.Version,
+		StorageFee: &ticket.RegTicketData.StorageFee,
 	}
 }

--- a/walletnode/services/artworksearch/search_test.go
+++ b/walletnode/services/artworksearch/search_test.go
@@ -27,7 +27,7 @@ func TestGetSearchableFields(t *testing.T) {
 					ArtworkSeriesName: "Science Art Lake",
 				},
 			},
-			TotalCopes: 10,
+			TotalCopies: 10,
 		},
 	}
 

--- a/walletnode/services/artworksearch/service.go
+++ b/walletnode/services/artworksearch/service.go
@@ -98,5 +98,5 @@ func (service *Service) GetThumbnail(ctx context.Context, regTicket *pastel.RegT
 	}
 	defer thumbnailHelper.Close()
 
-	return thumbnailHelper.Fetch(ctx, string(regTicket.RegTicketData.ArtTicketData.AppTicketData.ThumbnailHash))
+	return thumbnailHelper.Fetch(ctx, string(regTicket.RegTicketData.ArtTicketData.AppTicketData.PreviewHash))
 }

--- a/walletnode/services/artworksearch/task.go
+++ b/walletnode/services/artworksearch/task.go
@@ -112,7 +112,7 @@ func (task *Task) run(ctx context.Context) error {
 		res.MatchIndex = i
 
 		group.Go(func() error {
-			data, err := task.thumbnailHelper.Fetch(gctx, string(res.RegTicket.RegTicketData.ArtTicketData.AppTicketData.ThumbnailHash))
+			data, err := task.thumbnailHelper.Fetch(gctx, string(res.RegTicket.RegTicketData.ArtTicketData.AppTicketData.PreviewHash))
 			if err != nil {
 				log.WithContext(ctx).WithField("txid", res.TXID).WithError(err).Error("Fetch Thumbnail")
 
@@ -134,15 +134,16 @@ func (task *Task) run(ctx context.Context) error {
 
 // filterRegTicket filters ticket against request params & checks if its a match
 func (task *Task) filterRegTicket(regTicket *pastel.RegTicket) (srch *RegTicketSearch, matched bool) {
-	if !inIntRange(regTicket.RegTicketData.ArtTicketData.AppTicketData.RarenessScore,
-		task.request.MinRarenessScore, task.request.MaxRarenessScore) {
-		return srch, false
-	}
+	// FIXME
+	// if !inIntRange(regTicket.RegTicketData.ArtTicketData.AppTicketData.RarenessScore,
+	// 	task.request.MinRarenessScore, task.request.MaxRarenessScore) {
+	// 	return srch, false
+	// }
 
-	if !inIntRange(regTicket.RegTicketData.ArtTicketData.AppTicketData.NSFWScore,
-		task.request.MinNsfwScore, task.request.MaxNsfwScore) {
-		return srch, false
-	}
+	// if !inIntRange(regTicket.RegTicketData.ArtTicketData.AppTicketData.NSFWScore,
+	// 	task.request.MinNsfwScore, task.request.MaxNsfwScore) {
+	// 	return srch, false
+	// }
 
 	if !inIntRange(regTicket.RegTicketData.ArtTicketData.AppTicketData.TotalCopies,
 		task.request.MinCopies, task.request.MaxCopies) {


### PR DESCRIPTION
Update Art Reg structure with new changes in Rareness scores and other info as followings:
"fingerprints" []float
"dupe_detection_system_version" string
"matches_found_on_first_page" int
"number_of_pages_of_results" int
"url_of_first_match_in_page" string
"pastel_rareness_score" float
"internet_rareness_score" float
"open_nsfw_score" float
"alternate_nsfw_scores" object
"image_hashes" object

alternate NSFW scores object:
"drawings" float
"hentai" float
"neutral" float
"porn" float
"sexy" float

image hashes object:
"perceptual_hash" string
"average_hash" string
"average_hash" string