### PR TITLE
fixed bug when using actual dd database

### DIFF
--- a/dupedetection/go.sum
+++ b/dupedetection/go.sum
@@ -165,6 +165,7 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=

--- a/dupedetection/service.go
+++ b/dupedetection/service.go
@@ -125,13 +125,15 @@ func (s *service) getLatestFingerprint(ctx context.Context) (*dupeDetectionFinge
 		case "array":
 			b, ok := values[i].([]byte)
 			if !ok {
-				return nil, errors.New("failed to get byte from npy")
+				log.WithContext(ctx).Errorf("failed to get byte from npy, columns: %s", row[0].Columns[i])
+				continue
 			}
 			f := bytes.NewBuffer(b)
 
 			var fp []float64
 			if err := npyio.Read(f, &fp); err != nil {
-				return nil, errors.Errorf("failed to convert npy to float64, err: %s", err)
+				log.WithContext(ctx).Errorf("failed to convert npy to float64, err: %s", err)
+				continue
 			}
 			resultStr[row[0].Columns[i]] = fp
 		default:


### PR DESCRIPTION
Curretly dd database have `CREATE TABLE image_hash_to_image_fingerprint_table (sha256_hash_of_art_image_file text, path_to_art_image_file, model_1_image_fingerprint_vector array, model_2_image_fingerprint_vector array, model_3_image_fingerprint_vector array, model_4_image_fingerprint_vector array, model_5_image_fingerprint_vector array, model_6_image_fingerprint_vector array, model_7_image_fingerprint_vector array, datetime_fingerprint_added_to_database TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL, PRIMARY KEY (sha256_hash_of_art_image_file));`. There are many field don't use. So, this change will make sure reading fingerprint is fine