### PR TITLE
Fix default pastel config path

### DIFF
--- a/pastel/client.go
+++ b/pastel/client.go
@@ -445,14 +445,14 @@ func (client *client) callFor(ctx context.Context, object interface{}, method st
 
 // NewClient returns a new Client instance.
 func NewClient(config *Config) Client {
-	endpoint := net.JoinHostPort(config.hostname(), strconv.Itoa(config.port()))
+	endpoint := net.JoinHostPort(config.Hostname, strconv.Itoa(config.port()))
 	if !strings.Contains(endpoint, "//") {
 		endpoint = "http://" + endpoint
 	}
 
 	opts := &jsonrpc.RPCClientOpts{
 		CustomHeaders: map[string]string{
-			"Authorization": "Basic " + base64.StdEncoding.EncodeToString([]byte(config.username()+":"+config.password())),
+			"Authorization": "Basic " + base64.StdEncoding.EncodeToString([]byte(config.Username+":"+config.Password)),
 		},
 	}
 

--- a/pastel/config.go
+++ b/pastel/config.go
@@ -1,10 +1,13 @@
 package pastel
 
-import "encoding/json"
+import (
+	"encoding/json"
+)
 
 const (
-	defaultHostname = "localhost"
-	defaultPort     = 9932
+	defaultHostname    = "localhost"
+	defaultMainnetPort = 9932
+	defaultTestnetPort = 19932
 )
 
 // ExternalConfig represents the structure of the `pastel.conf` file.
@@ -13,6 +16,7 @@ type ExternalConfig struct {
 	Port     int    `mapstructure:"rpcport"`
 	Username string `mapstructure:"rpcuser"`
 	Password string `mapstructure:"rpcpassword"`
+	Testnet  int    `mapstructure:"testnet"`
 }
 
 // Config contains settings of the Pastel client.
@@ -53,7 +57,16 @@ func (config *Config) port() int {
 	if config.Port != nil {
 		return *config.Port
 	}
-	return config.ExternalConfig.Port
+
+	if config.ExternalConfig.Port != 0 {
+		return config.ExternalConfig.Port
+	}
+
+	if config.ExternalConfig.Testnet == 1 {
+		return defaultTestnetPort
+	}
+
+	return defaultMainnetPort
 }
 
 // Username returns username port if it is specified, otherwise returns username from external config.
@@ -77,7 +90,6 @@ func NewConfig() *Config {
 	return &Config{
 		ExternalConfig: &ExternalConfig{
 			Hostname: defaultHostname,
-			Port:     defaultPort,
 		},
 	}
 }

--- a/pastel/config.go
+++ b/pastel/config.go
@@ -10,23 +10,13 @@ const (
 	defaultTestnetPort = 19932
 )
 
-// ExternalConfig represents the structure of the `pastel.conf` file.
-type ExternalConfig struct {
+// Config Represents the structure of the `pastel.conf` file.
+type Config struct {
 	Hostname string `mapstructure:"rpcconnect"`
 	Port     int    `mapstructure:"rpcport"`
 	Username string `mapstructure:"rpcuser"`
 	Password string `mapstructure:"rpcpassword"`
 	Testnet  int    `mapstructure:"testnet"`
-}
-
-// Config contains settings of the Pastel client.
-type Config struct {
-	*ExternalConfig
-
-	Hostname *string `mapstructure:"hostname"`
-	Port     *int    `mapstructure:"port"`
-	Username *string `mapstructure:"username"`
-	Password *string `mapstructure:"password"`
 }
 
 // MarshalJSON returns the JSON encoding.
@@ -37,59 +27,31 @@ func (config *Config) MarshalJSON() ([]byte, error) {
 		Username string `json:"username,omitempty"`
 		Password string `json:"-"`
 	}{
-		Hostname: config.hostname(),
+		Hostname: config.Hostname,
 		Port:     config.port(),
-		Username: config.username(),
-		Password: config.password(),
+		Username: config.Username,
+		Password: config.Password,
 	})
 }
 
-// Hostname returns node hostname if it is specified, otherwise returns hostname from external config.
-func (config *Config) hostname() string {
-	if config.Hostname != nil {
-		return *config.Hostname
-	}
-	return config.ExternalConfig.Hostname
-}
-
-// Port returns node port if it is specified, otherwise returns port from external config.
+// Port returns port from external config.
+// if port is not provided & testnet=1 it uses default testnet port
+// else it uses default mainnet port
 func (config *Config) port() int {
-	if config.Port != nil {
-		return *config.Port
+	if config.Port != 0 {
+		return config.Port
 	}
 
-	if config.ExternalConfig.Port != 0 {
-		return config.ExternalConfig.Port
-	}
-
-	if config.ExternalConfig.Testnet == 1 {
+	if config.Testnet == 1 {
 		return defaultTestnetPort
 	}
 
 	return defaultMainnetPort
 }
 
-// Username returns username port if it is specified, otherwise returns username from external config.
-func (config *Config) username() string {
-	if config.Username != nil {
-		return *config.Username
-	}
-	return config.ExternalConfig.Username
-}
-
-// Password returns password port if it is specified, otherwise returns password from external config.
-func (config *Config) password() string {
-	if config.Password != nil {
-		return *config.Password
-	}
-	return config.ExternalConfig.Password
-}
-
 // NewConfig returns a new Config instance.
 func NewConfig() *Config {
 	return &Config{
-		ExternalConfig: &ExternalConfig{
-			Hostname: defaultHostname,
-		},
+		Hostname: defaultHostname,
 	}
 }

--- a/pastel/config_test.go
+++ b/pastel/config_test.go
@@ -1,0 +1,117 @@
+package pastel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPort(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		cfg          *Config
+		wantPort     int
+		wantUsername string
+		wantPassword string
+		wantHostname string
+	}{
+		"simple": {
+			cfg:          NewConfig(),
+			wantPort:     defaultMainnetPort,
+			wantHostname: defaultHostname,
+		},
+		"testnet-on": {
+			cfg: &Config{
+				ExternalConfig: &ExternalConfig{
+					Port:     0,
+					Testnet:  1,
+					Username: "rpc",
+					Hostname: "test",
+				},
+			},
+			wantUsername: "rpc",
+			wantHostname: "test",
+			wantPort:     defaultTestnetPort,
+		},
+		"test-username": {
+			cfg: &Config{
+				ExternalConfig: &ExternalConfig{
+					Port:     0,
+					Testnet:  1,
+					Username: "rpc",
+				},
+			},
+			wantUsername: "rpc",
+			wantPort:     defaultTestnetPort,
+		},
+		"test-hostname": {
+			cfg: &Config{
+				ExternalConfig: &ExternalConfig{
+					Port:     0,
+					Testnet:  1,
+					Hostname: "test",
+				},
+			},
+			wantHostname: "test",
+			wantPort:     defaultTestnetPort,
+		},
+		"test-password": {
+			cfg: &Config{
+				ExternalConfig: &ExternalConfig{
+					Port:     0,
+					Testnet:  1,
+					Password: "test",
+				},
+			},
+			wantPassword: "test",
+			wantPort:     defaultTestnetPort,
+		},
+		"testnet-off": {
+			cfg: &Config{
+				ExternalConfig: &ExternalConfig{
+					Port:    0,
+					Testnet: 0,
+				},
+			},
+			wantPort: defaultMainnetPort,
+		},
+		"testnet-on-port-provided": {
+			cfg: &Config{
+				ExternalConfig: &ExternalConfig{
+					Port:    12170,
+					Testnet: 1,
+				},
+			},
+			wantPort: 12170,
+		},
+		"testnet-off-port-provided": {
+			cfg: &Config{
+				ExternalConfig: &ExternalConfig{
+					Port:    12170,
+					Testnet: 0,
+				},
+			},
+			wantPort: 12170,
+		},
+	}
+
+	for name, tc := range tests {
+		tc := tc
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := tc.cfg.port()
+			assert.Equal(t, tc.wantPort, got)
+
+			gotVal := tc.cfg.username()
+			assert.Equal(t, tc.wantUsername, gotVal)
+
+			gotVal = tc.cfg.hostname()
+			assert.Equal(t, tc.wantHostname, gotVal)
+
+			gotVal = tc.cfg.password()
+			assert.Equal(t, tc.wantPassword, gotVal)
+		})
+	}
+}

--- a/pastel/config_test.go
+++ b/pastel/config_test.go
@@ -10,87 +10,39 @@ func TestPort(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]struct {
-		cfg          *Config
-		wantPort     int
-		wantUsername string
-		wantPassword string
-		wantHostname string
+		cfg      *Config
+		wantPort int
 	}{
 		"simple": {
-			cfg:          NewConfig(),
-			wantPort:     defaultMainnetPort,
-			wantHostname: defaultHostname,
+			cfg:      NewConfig(),
+			wantPort: defaultMainnetPort,
 		},
 		"testnet-on": {
 			cfg: &Config{
-				ExternalConfig: &ExternalConfig{
-					Port:     0,
-					Testnet:  1,
-					Username: "rpc",
-					Hostname: "test",
-				},
+				Port:    0,
+				Testnet: 1,
 			},
-			wantUsername: "rpc",
-			wantHostname: "test",
-			wantPort:     defaultTestnetPort,
-		},
-		"test-username": {
-			cfg: &Config{
-				ExternalConfig: &ExternalConfig{
-					Port:     0,
-					Testnet:  1,
-					Username: "rpc",
-				},
-			},
-			wantUsername: "rpc",
-			wantPort:     defaultTestnetPort,
-		},
-		"test-hostname": {
-			cfg: &Config{
-				ExternalConfig: &ExternalConfig{
-					Port:     0,
-					Testnet:  1,
-					Hostname: "test",
-				},
-			},
-			wantHostname: "test",
-			wantPort:     defaultTestnetPort,
-		},
-		"test-password": {
-			cfg: &Config{
-				ExternalConfig: &ExternalConfig{
-					Port:     0,
-					Testnet:  1,
-					Password: "test",
-				},
-			},
-			wantPassword: "test",
-			wantPort:     defaultTestnetPort,
+			wantPort: defaultTestnetPort,
 		},
 		"testnet-off": {
 			cfg: &Config{
-				ExternalConfig: &ExternalConfig{
-					Port:    0,
-					Testnet: 0,
-				},
+				Port:    0,
+				Testnet: 0,
 			},
 			wantPort: defaultMainnetPort,
 		},
 		"testnet-on-port-provided": {
 			cfg: &Config{
-				ExternalConfig: &ExternalConfig{
-					Port:    12170,
-					Testnet: 1,
-				},
+
+				Port:    12170,
+				Testnet: 1,
 			},
 			wantPort: 12170,
 		},
 		"testnet-off-port-provided": {
 			cfg: &Config{
-				ExternalConfig: &ExternalConfig{
-					Port:    12170,
-					Testnet: 0,
-				},
+				Port:    12170,
+				Testnet: 0,
 			},
 			wantPort: 12170,
 		},
@@ -103,15 +55,6 @@ func TestPort(t *testing.T) {
 			t.Parallel()
 			got := tc.cfg.port()
 			assert.Equal(t, tc.wantPort, got)
-
-			gotVal := tc.cfg.username()
-			assert.Equal(t, tc.wantUsername, gotVal)
-
-			gotVal = tc.cfg.hostname()
-			assert.Equal(t, tc.wantHostname, gotVal)
-
-			gotVal = tc.cfg.password()
-			assert.Equal(t, tc.wantPassword, gotVal)
 		})
 	}
 }

--- a/supernode/cmd/app.go
+++ b/supernode/cmd/app.go
@@ -89,7 +89,7 @@ func NewApp() *cli.App {
 			}
 		}
 		if pastelConfigFile != "" {
-			if err := configurer.ParseFile(pastelConfigFile, config.Pastel.ExternalConfig); err != nil {
+			if err := configurer.ParseFile(pastelConfigFile, config.Pastel); err != nil {
 				log.WithContext(ctx).Debug(err)
 			}
 		}

--- a/supernode/cmd/app.go
+++ b/supernode/cmd/app.go
@@ -69,8 +69,8 @@ func NewApp() *cli.App {
 
 	app.AddFlags(
 		// Main
-		cli.NewFlag("config-file", &configFile).SetUsage("Set `path` to the config file.").SetDefaultText(defaultConfigFile).SetAliases("c"),
-		cli.NewFlag("pastel-config-file", &pastelConfigFile).SetUsage("Set `path` to the pastel config file.").SetDefaultText(defaultPastelConfigFile),
+		cli.NewFlag("config-file", &configFile).SetUsage("Set `path` to the config file.").SetValue(defaultConfigFile).SetAliases("c"),
+		cli.NewFlag("pastel-config-file", &pastelConfigFile).SetUsage("Set `path` to the pastel config file.").SetValue(defaultPastelConfigFile),
 		cli.NewFlag("work-dir", &config.WorkDir).SetUsage("Set `path` for storing work data.").SetValue(defaultWorkDir),
 		cli.NewFlag("temp-dir", &config.TempDir).SetUsage("Set `path` for storing temp data.").SetValue(defaultTempDir),
 		cli.NewFlag("rq-files-dir", &config.RqFilesDir).SetUsage("Set `path` for storing files for rqservice.").SetValue(defaultRqFilesDir),

--- a/supernode/cmd/app.go
+++ b/supernode/cmd/app.go
@@ -85,12 +85,12 @@ func NewApp() *cli.App {
 
 		if configFile != "" {
 			if err := configurer.ParseFile(configFile, config); err != nil {
-				return err
+				return fmt.Errorf("error parsing supernode config file: %v", err)
 			}
 		}
 		if pastelConfigFile != "" {
 			if err := configurer.ParseFile(pastelConfigFile, config.Pastel); err != nil {
-				log.WithContext(ctx).Debug(err)
+				return fmt.Errorf("error parsing pastel config file: %v", err)
 			}
 		}
 

--- a/supernode/configs/config.go
+++ b/supernode/configs/config.go
@@ -28,7 +28,7 @@ type Config struct {
 	DdWorkDir  string `mapstructure:"dd-service-dir" json:"dd-service-dir"`
 
 	Node          `mapstructure:"node" json:"node,omitempty"`
-	Pastel        *pastel.Config        `mapstructure:"pastel-api" json:"pastel-api,omitempty"`
+	Pastel        *pastel.Config        `mapstructure:"-" json:"-"`
 	P2P           *p2p.Config           `mapstructure:"p2p" json:"p2p,omitempty"`
 	MetaDB        *metadb.Config        `mapstructure:"metadb" json:"metadb,omitempty"`
 	UserDB        *database.Config      `mapstructure:"userdb" json:"userdb,omitempty"`

--- a/supernode/examples/configs/localnet-4444.yml
+++ b/supernode/examples/configs/localnet-4444.yml
@@ -1,9 +1,4 @@
-pastel-api:
-  hostname: "127.0.0.1"
-  port: 12156 
-  username: "rt"
-  password: "rt"
-
+# please provide pastel configs in pastel.conf
 node:
   pastel_id: jXXsFY5CMSFy5T1cHFiqTsK2B5kMv93zP48G2FdfPWuPP6p2jH6c1JrNGL3VJHDxFvq6eZSsWppC3191sbG3oD
   pass_phrase: "passphrase"

--- a/supernode/examples/configs/localnet-4445.yml
+++ b/supernode/examples/configs/localnet-4445.yml
@@ -1,9 +1,3 @@
-pastel-api:
-  hostname: "127.0.0.1"
-  port: 12157
-  username: "rt"
-  password: "rt"
-
 node:
   pastel_id: jXYRUAYogZ2ZPYhHgTp6feHkwaTuFNSdj49Hy4B9bmGEtGfETGpRTFtyiVwZyBKu3XDuWwHZH78YKFFBpgJXr1
   pass_phrase: "passphrase"

--- a/supernode/examples/configs/localnet-4446.yml
+++ b/supernode/examples/configs/localnet-4446.yml
@@ -1,9 +1,3 @@
-pastel-api:
-  hostname: "127.0.0.1"
-  port: 12158
-  username: "rt"
-  password: "rt"
-
 node:
   pastel_id: jXYUbc59imKKoSNFdu7BcNbCBULS21MBBe8GjzfRXi9vGZrXV1y7ihJwY9ib8xTB8cSnsatvNroNJ8b7DN4Rrd
   pass_phrase: "passphrase"

--- a/supernode/examples/configs/localnet-4447.yml
+++ b/supernode/examples/configs/localnet-4447.yml
@@ -1,9 +1,3 @@
-pastel-api:
-  hostname: "127.0.0.1"
-  port: 29932
-  username: "4447"
-  password: ""
-
 node:
   pastel_id: jXZDyPoescC4pgWMeD2qMzyPi5gaxMkkggrwGFAK2izTQgEkrjKqHSbG1HCfCFY9n3pAQ9q4VFHLrakL89bvfR
   server:

--- a/supernode/examples/configs/testnet.yml
+++ b/supernode/examples/configs/testnet.yml
@@ -1,6 +1,4 @@
-pastel-api:
-  port: 19932
-
+# please provide pastel configs in pastel.conf
 node:
   # `pastel_id` must match to active `PastelID` from masternode.
   # To check it out first get the active outpoint from `masteronde status`, then filter the result of `tickets list id mine` by this outpoint.

--- a/walletnode/cmd/app.go
+++ b/walletnode/cmd/app.go
@@ -80,7 +80,7 @@ func NewApp() *cli.App {
 		}
 
 		if pastelConfigFile != "" {
-			if err := configurer.ParseFile(pastelConfigFile, config.Pastel.ExternalConfig); err != nil {
+			if err := configurer.ParseFile(pastelConfigFile, config.Pastel); err != nil {
 				log.WithContext(ctx).Debug(err)
 			}
 		}

--- a/walletnode/cmd/app.go
+++ b/walletnode/cmd/app.go
@@ -75,13 +75,13 @@ func NewApp() *cli.App {
 
 		if configFile != "" {
 			if err := configurer.ParseFile(configFile, config); err != nil {
-				return err
+				return fmt.Errorf("error parsing walletnode config file: %v", err)
 			}
 		}
 
 		if pastelConfigFile != "" {
 			if err := configurer.ParseFile(pastelConfigFile, config.Pastel); err != nil {
-				log.WithContext(ctx).Debug(err)
+				return fmt.Errorf("error parsing pastel config: %v", err)
 			}
 		}
 

--- a/walletnode/cmd/app.go
+++ b/walletnode/cmd/app.go
@@ -59,8 +59,8 @@ func NewApp() *cli.App {
 
 	app.AddFlags(
 		// Main
-		cli.NewFlag("config-file", &configFile).SetUsage("Set `path` to the config file.").SetDefaultText(defaultConfigFile).SetAliases("c"),
-		cli.NewFlag("pastel-config-file", &pastelConfigFile).SetUsage("Set `path` to the pastel config file.").SetDefaultText(defaultPastelConfigFile),
+		cli.NewFlag("config-file", &configFile).SetUsage("Set `path` to the config file.").SetValue(defaultConfigFile).SetAliases("c"),
+		cli.NewFlag("pastel-config-file", &pastelConfigFile).SetUsage("Set `path` to the pastel config file.").SetValue(defaultPastelConfigFile),
 		cli.NewFlag("temp-dir", &config.TempDir).SetUsage("Set `path` for storing temp data.").SetValue(defaultTempDir),
 		cli.NewFlag("rq-files-dir", &config.RqFilesDir).SetUsage("Set `path` for storing files for rqservice.").SetValue(defaultRqFilesDir),
 		cli.NewFlag("log-level", &config.LogLevel).SetUsage("Set the log `level`.").SetValue(config.LogLevel),
@@ -78,6 +78,7 @@ func NewApp() *cli.App {
 				return err
 			}
 		}
+
 		if pastelConfigFile != "" {
 			if err := configurer.ParseFile(pastelConfigFile, config.Pastel.ExternalConfig); err != nil {
 				log.WithContext(ctx).Debug(err)

--- a/walletnode/configs/config.go
+++ b/walletnode/configs/config.go
@@ -22,7 +22,7 @@ type Config struct {
 	RqFilesDir string `mapstructure:"rq-files-dir" json:"rq-files-dir"`
 
 	Node    `mapstructure:"node" json:"node,omitempty"`
-	Pastel  *pastel.Config  `mapstructure:"pastel-api" json:"pastel-api,omitempty"`
+	Pastel  *pastel.Config  `mapstructure:"-" json:"-"`
 	P2P     *p2p.Config     `mapstructure:"p2p" json:"p2p,omitempty"`
 	RaptorQ *raptorq.Config `mapstructure:"raptorq" json:"raptorq,omitempty"`
 }

--- a/walletnode/examples/configs/localnet.yml
+++ b/walletnode/examples/configs/localnet.yml
@@ -1,9 +1,4 @@
-pastel-api:
-  hostname: "127.0.0.1"
-  port: 12170
-  username: "rt"
-  password: "rt"
-
+# please provide pastel configs in pastel.conf
 node:
   api:
     hostname: "localhost"

--- a/walletnode/examples/configs/testnet.yml
+++ b/walletnode/examples/configs/testnet.yml
@@ -1,6 +1,4 @@
-pastel-api:
-  port: 19932
-
+# please provide pastel configs in pastel.conf
 node:
   api:
     hostname: "localhost"


### PR DESCRIPTION
- Fixes default pastel conf file path assigning
- SN & WN should not provide pastel configs in their own config files, rather, they should
    read pastel configs from pastel.conf
- Handle testnet param in pastel.conf
- Add unit test case