### PR TITLE
Generate goa again without manual adding 'defer cancel()'

### DIFF
--- a/walletnode/api/gen/http/artworks/client/client.go
+++ b/walletnode/api/gen/http/artworks/client/client.go
@@ -143,7 +143,6 @@ func (c *Client) RegisterTaskState() goa.Endpoint {
 		}
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithCancel(ctx)
-		defer cancel()
 		conn, resp, err := c.dialer.DialContext(ctx, req.URL.String(), req.Header)
 		if err != nil {
 			if resp != nil {
@@ -248,7 +247,6 @@ func (c *Client) ArtSearch() goa.Endpoint {
 		}
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithCancel(ctx)
-		defer cancel()
 		conn, resp, err := c.dialer.DialContext(ctx, req.URL.String(), req.Header)
 		if err != nil {
 			if resp != nil {

--- a/walletnode/api/gen/http/artworks/client/client.go
+++ b/walletnode/api/gen/http/artworks/client/client.go
@@ -142,7 +142,8 @@ func (c *Client) RegisterTaskState() goa.Endpoint {
 			return nil, err
 		}
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithCancel(ctx)
+		_, cancel = context.WithCancel(ctx)
+		defer cancel()
 		conn, resp, err := c.dialer.DialContext(ctx, req.URL.String(), req.Header)
 		if err != nil {
 			if resp != nil {
@@ -246,7 +247,8 @@ func (c *Client) ArtSearch() goa.Endpoint {
 			return nil, err
 		}
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithCancel(ctx)
+		_, cancel = context.WithCancel(ctx)
+		defer cancel()
 		conn, resp, err := c.dialer.DialContext(ctx, req.URL.String(), req.Header)
 		if err != nil {
 			if resp != nil {


### PR DESCRIPTION
- Fix issue of manual adding `defer cancel()` to generated code of goa make websocket connection closed early.