### PR TITLE
Fix dead lock when start database

### DIFF
--- a/metadb/database/service.go
+++ b/metadb/database/service.go
@@ -122,7 +122,10 @@ func (db *Ops) Run(ctx context.Context) error {
 
 	content := schemaV1Content
 
-	db.metaDB.WaitForStarting()
+	if err := db.metaDB.WaitForStarting(ctx); err != nil {
+		return errors.Errorf("error while waiting for starting: %w", err)
+	}
+
 	if db.metaDB.IsLeader() {
 		listOfCommands := strings.Split(content, schemaDelimiter)
 		for _, cmd := range listOfCommands {

--- a/metadb/database/service_test.go
+++ b/metadb/database/service_test.go
@@ -361,7 +361,7 @@ func (ts *testSuite) SetupSuite() {
 		// start the rqlite server
 		ts.Nil(db.Run(ts.ctx), "run service")
 	}()
-	db.WaitForStarting()
+	db.WaitForStarting(ts.ctx)
 	_, err = db.Write(ts.ctx, schema)
 
 	ts.Nil(err)

--- a/metadb/metadb.go
+++ b/metadb/metadb.go
@@ -20,7 +20,7 @@ type MetaDB interface {
 	// Write execute a statement, not support multple statements
 	Write(ctx context.Context, statement string) (*WriteResult, error)
 	// WaitForStarting wait for the db to completely started, just run once after starting up the db
-	WaitForStarting()
+	WaitForStarting(ctx context.Context) error
 	// LeaderAddr returns the address of the current leader. Returns a
 	// blank string if there is no leader.
 	LeaderAddress() string

--- a/metadb/server.go
+++ b/metadb/server.go
@@ -205,7 +205,12 @@ func (s *service) startServer(ctx context.Context) error {
 		return errors.Errorf("start http server: %w", err)
 	}
 	// mark the rqlite node is ready
-	s.ready <- struct{}{}
+	select {
+	case <-ctx.Done():
+		return errors.Errorf("context done: %w", ctx.Err())
+	case s.ready <- struct{}{}:
+		// do nothing, continue
+	}
 
 	log.WithContext(ctx).Info("metadb service is started")
 

--- a/metadb/store.go
+++ b/metadb/store.go
@@ -18,8 +18,13 @@ const (
 )
 
 // WaitForStarting wait for the db to completely started, just run once after starting up the db
-func (s *service) WaitForStarting() {
-	<-s.ready
+func (s *service) WaitForStarting(ctx context.Context) error {
+	select {
+	case <-s.ready:
+		return nil
+	case <-ctx.Done():
+		return errors.Errorf("context done: %w", ctx.Err())
+	}
 }
 
 // LeaderAddr returns the address of the current leader. Returns a


### PR DESCRIPTION
In case of func (s *service) startServer(ctx context.Context) of metadb stop before notify s.ready channel.
Then db.metaDB.WaitForStarting() will get stuck forever.