### PR TITLE
Add secure connection to p2p with pools

### DIFF
--- a/p2p/kademlia/conn_pool.go
+++ b/p2p/kademlia/conn_pool.go
@@ -1,0 +1,83 @@
+package kademlia
+
+import (
+	"fmt"
+	"net"
+	"sync"
+	"time"
+)
+
+const defaultCapacity = 128
+
+type ConnectionItem struct {
+	lastAccess time.Time
+	conn       net.Conn
+	rawConn    net.Conn
+}
+
+type ConnPool struct {
+	capacity int
+	conns    map[string]*ConnectionItem
+	mtx      sync.Mutex
+}
+
+func NewConnPool() *ConnPool {
+	return &ConnPool{
+		capacity: defaultCapacity,
+		conns:    map[string]*ConnectionItem{},
+	}
+}
+
+func (pool *ConnPool) Add(addr string, conn net.Conn, rawConn net.Conn) {
+	pool.mtx.Lock()
+	defer pool.mtx.Unlock()
+
+	if len(pool.conns) >= pool.capacity {
+		oldestAccess := time.Now()
+		oldestAccessAddr := ""
+
+		for addr, item := range pool.conns {
+			if item.lastAccess.Before(oldestAccess) {
+				oldestAccessAddr = addr
+				oldestAccess = item.lastAccess
+			}
+		}
+
+		delete(pool.conns, oldestAccessAddr)
+	}
+
+	pool.conns[addr] = &ConnectionItem{
+		lastAccess: time.Now(),
+		conn:       conn,
+		rawConn:    rawConn,
+	}
+}
+
+func (pool *ConnPool) Get(addr string) (net.Conn, net.Conn, error) {
+	pool.mtx.Lock()
+	defer pool.mtx.Unlock()
+	item, ok := pool.conns[addr]
+	if !ok {
+		return nil, nil, fmt.Errorf("not found")
+	}
+
+	item.lastAccess = time.Now()
+	return item.conn, item.rawConn, nil
+}
+
+func (pool *ConnPool) Del(addr string) {
+	pool.mtx.Lock()
+	defer pool.mtx.Unlock()
+	delete(pool.conns, addr)
+}
+
+func (pool *ConnPool) Release() {
+	pool.mtx.Lock()
+	defer pool.mtx.Unlock()
+
+	for addr, item := range pool.conns {
+		item.rawConn.Close()
+		item.conn.Close()
+		delete(pool.conns, addr)
+	}
+}

--- a/p2p/kademlia/conn_pool.go
+++ b/p2p/kademlia/conn_pool.go
@@ -1,10 +1,15 @@
 package kademlia
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"sync"
 	"time"
+
+	"github.com/anacrolix/utp"
+	"github.com/pastelnetwork/gonode/common/errors"
+	"google.golang.org/grpc/credentials"
 )
 
 const defaultCapacity = 128
@@ -12,7 +17,6 @@ const defaultCapacity = 128
 type ConnectionItem struct {
 	lastAccess time.Time
 	conn       net.Conn
-	rawConn    net.Conn
 }
 
 type ConnPool struct {
@@ -28,7 +32,7 @@ func NewConnPool() *ConnPool {
 	}
 }
 
-func (pool *ConnPool) Add(addr string, conn net.Conn, rawConn net.Conn) {
+func (pool *ConnPool) Add(addr string, conn net.Conn) {
 	pool.mtx.Lock()
 	defer pool.mtx.Unlock()
 
@@ -49,20 +53,19 @@ func (pool *ConnPool) Add(addr string, conn net.Conn, rawConn net.Conn) {
 	pool.conns[addr] = &ConnectionItem{
 		lastAccess: time.Now(),
 		conn:       conn,
-		rawConn:    rawConn,
 	}
 }
 
-func (pool *ConnPool) Get(addr string) (net.Conn, net.Conn, error) {
+func (pool *ConnPool) Get(addr string) (net.Conn, error) {
 	pool.mtx.Lock()
 	defer pool.mtx.Unlock()
 	item, ok := pool.conns[addr]
 	if !ok {
-		return nil, nil, fmt.Errorf("not found")
+		return nil, fmt.Errorf("not found")
 	}
 
 	item.lastAccess = time.Now()
-	return item.conn, item.rawConn, nil
+	return item.conn, nil
 }
 
 func (pool *ConnPool) Del(addr string) {
@@ -76,8 +79,96 @@ func (pool *ConnPool) Release() {
 	defer pool.mtx.Unlock()
 
 	for addr, item := range pool.conns {
-		item.rawConn.Close()
 		item.conn.Close()
 		delete(pool.conns, addr)
 	}
+}
+
+type connWrapper struct {
+	secureConn net.Conn
+	rawConn    net.Conn
+	mtx        sync.Mutex
+}
+
+func NewSecureClientConn(tpCredentials credentials.TransportCredentials, ctx context.Context, remoteAddr string) (net.Conn, error) {
+	// dial the remote address with udp network
+	rawConn, err := utp.DialContext(ctx, remoteAddr)
+	if err != nil {
+		return nil, errors.Errorf("dial %q: %w", remoteAddr, err)
+	}
+
+	// set the deadline for read and write
+	rawConn.SetDeadline(time.Now().Add(defaultConnDeadline))
+
+	conn, _, err := tpCredentials.ClientHandshake(ctx, "", rawConn)
+	if err != nil {
+		rawConn.Close()
+		return nil, errors.Errorf("client secure establish %q: %w", remoteAddr, err)
+	}
+
+	return &connWrapper{
+		secureConn: conn,
+		rawConn:    rawConn,
+	}, nil
+}
+
+func NewSecureServerConn(tpCredentials credentials.TransportCredentials, ctx context.Context, rawConn net.Conn) (net.Conn, error) {
+	conn, _, err := tpCredentials.ServerHandshake(rawConn)
+	if err != nil {
+		return nil, errors.Errorf("server secure establish failed")
+	}
+
+	return &connWrapper{
+		secureConn: conn,
+		rawConn:    rawConn,
+	}, nil
+}
+
+func (conn *connWrapper) Read(b []byte) (n int, err error) {
+	conn.mtx.Lock()
+	defer conn.mtx.Unlock()
+	return conn.secureConn.Read(b)
+}
+
+func (conn *connWrapper) Write(b []byte) (n int, err error) {
+	conn.mtx.Lock()
+	defer conn.mtx.Unlock()
+	return conn.secureConn.Write(b)
+}
+
+func (conn *connWrapper) Close() error {
+	conn.mtx.Lock()
+	defer conn.mtx.Unlock()
+	conn.secureConn.Close()
+	return conn.rawConn.Close()
+}
+
+func (conn *connWrapper) LocalAddr() net.Addr {
+	conn.mtx.Lock()
+	defer conn.mtx.Unlock()
+	return conn.rawConn.LocalAddr()
+}
+
+func (conn *connWrapper) RemoteAddr() net.Addr {
+	conn.mtx.Lock()
+	defer conn.mtx.Unlock()
+	return conn.rawConn.RemoteAddr()
+}
+
+func (conn *connWrapper) SetDeadline(t time.Time) error {
+	conn.mtx.Lock()
+	defer conn.mtx.Unlock()
+	return conn.rawConn.SetDeadline(t)
+}
+
+func (conn *connWrapper) SetReadDeadline(t time.Time) error {
+	conn.mtx.Lock()
+	defer conn.mtx.Unlock()
+	return conn.rawConn.SetReadDeadline(t)
+}
+
+func (conn *connWrapper) SetWriteDeadline(t time.Time) error {
+	conn.mtx.Lock()
+	defer conn.mtx.Unlock()
+	return conn.rawConn.SetWriteDeadline(t)
 }

--- a/p2p/kademlia/dht_test.go
+++ b/p2p/kademlia/dht_test.go
@@ -428,7 +428,7 @@ func (ts *testSuite) TestStoreWith10Nodes() {
 }
 
 func (ts *testSuite) TestIterativeFindNode() {
-	start, end := 1, 10
+	start, end := 11, 20
 	// start the nodes
 	dhts, err := ts.startNodes(start, end)
 	if err != nil {
@@ -448,7 +448,7 @@ func (ts *testSuite) TestIterativeFindNode() {
 }
 
 func (ts *testSuite) TestIterativeFindValue() {
-	start, end := 1, 2
+	start, end := 21, 22
 	// start the nodes
 	dhts, err := ts.startNodes(start, end)
 	if err != nil {
@@ -573,7 +573,7 @@ func (ts *testSuite) TestHashKey() {
 }
 
 func (ts *testSuite) TestRateLimiter() {
-	start, end := 10, 20
+	start, end := 23, 32
 	// start 10 nodes
 	dhts, err := ts.startNodes(start, end)
 	if err != nil {

--- a/p2p/kademlia/network.go
+++ b/p2p/kademlia/network.go
@@ -197,7 +197,7 @@ func (s *Network) handleConn(ctx context.Context, rawConn net.Conn) {
 
 	// do secure handshaking
 	if s.tpCredentials != nil {
-		conn, err = NewSecureServerConn(s.tpCredentials, ctx, rawConn)
+		conn, err = NewSecureServerConn(ctx, s.tpCredentials, rawConn)
 		if err != nil {
 			rawConn.Close()
 			log.WithContext(ctx).WithError(err).Error("server secure establish failed")
@@ -327,7 +327,7 @@ func (s *Network) Call(ctx context.Context, request *Message) (*Message, error) 
 		s.connPoolMtx.Lock()
 		conn, err = s.connPool.Get(remoteAddr)
 		if err != nil {
-			conn, err = NewSecureClientConn(s.tpCredentials, ctx, remoteAddr)
+			conn, err = NewSecureClientConn(ctx, s.tpCredentials, remoteAddr)
 			if err != nil {
 				s.connPoolMtx.Unlock()
 				return nil, errors.Errorf("client secure establish %q: %w", remoteAddr, err)


### PR DESCRIPTION
Add connection pool to manage a pool of connection to other nodes - prevent create new connection for each request - reduce overhead of key exchange at initial establishment.
Shoud merge https://github.com/pastelnetwork/gonode/pull/199/files first, then change base to master.