### PR TITLE
Should not cancel task when connection is not accepted

### DIFF
--- a/supernode/node/grpc/server/services/supernode/register_artwork.go
+++ b/supernode/node/grpc/server/services/supernode/register_artwork.go
@@ -28,6 +28,7 @@ func (service *RegisterArtwork) Session(stream pb.RegisterArtwork_SessionServer)
 	defer cancel()
 
 	var task *artworkregister.Task
+	isTaskNew := false
 
 	if sessID, ok := service.SessID(ctx); ok {
 		if task = service.Task(sessID); task == nil {
@@ -35,12 +36,16 @@ func (service *RegisterArtwork) Session(stream pb.RegisterArtwork_SessionServer)
 		}
 	} else {
 		task = service.NewTask()
+		isTaskNew = true
 	}
 	go func() {
 		<-task.Done()
 		cancel()
 	}()
-	defer task.Cancel()
+
+	if isTaskNew {
+		defer task.Cancel()
+	}
 
 	peer, _ := peer.FromContext(ctx)
 	log.WithContext(ctx).WithField("addr", peer.Addr).Debugf("Session stream")
@@ -54,6 +59,10 @@ func (service *RegisterArtwork) Session(stream pb.RegisterArtwork_SessionServer)
 
 	if err := task.SessionNode(ctx, req.NodeID); err != nil {
 		return err
+	}
+
+	if !isTaskNew {
+		defer task.Cancel()
 	}
 
 	resp := &pb.SessionReply{


### PR DESCRIPTION
when connect request from secondary node come - and it's rejected, it cancel task - result in cancelling all accepted connections to primary node.