### PR TITLE
unify loggings + improve mesh creation

### DIFF
--- a/common/image/qrsignature/payload.go
+++ b/common/image/qrsignature/payload.go
@@ -56,12 +56,12 @@ func (payload *Payload) Decode() error {
 
 	raw, err := base64.StdEncoding.DecodeString(data)
 	if err != nil {
-		return errors.Errorf("failed to decode text to binary data: %w", err)
+		return errors.Errorf("decode: %w", err)
 	}
 
 	raw, err = zstd.Decompress(nil, raw)
 	if err != nil {
-		return errors.Errorf("failed to decompress binary data: %w", err)
+		return errors.Errorf("decompress: %w", err)
 	}
 	payload.raw = raw
 	return nil
@@ -71,7 +71,7 @@ func (payload *Payload) Decode() error {
 func (payload *Payload) Encode() error {
 	raw, err := zstd.CompressLevel(nil, payload.raw, 22)
 	if err != nil {
-		return errors.Errorf("failed to compress binary data: %w", err)
+		return errors.Errorf("compress: %w", err)
 	}
 
 	data := base64.StdEncoding.EncodeToString(raw)

--- a/common/image/qrsignature/qrcode.go
+++ b/common/image/qrsignature/qrcode.go
@@ -45,11 +45,11 @@ type QRCode struct {
 func (qr *QRCode) Decode() (string, error) {
 	bmp, err := gozxing.NewBinaryBitmapFromImage(qr.Image)
 	if err != nil {
-		return "", errors.Errorf("failed to get bitmap from the QR code image :%w", err)
+		return "", errors.Errorf("get bitmap from the QR code image: %w", err)
 	}
 	result, err := qr.reader.Decode(bmp, nil)
 	if err != nil {
-		return "", errors.Errorf("failed to decode a QR code :%w", err)
+		return "", errors.Errorf("decode a QR code: %w", err)
 	}
 
 	return result.GetText(), nil
@@ -59,7 +59,7 @@ func (qr *QRCode) Decode() (string, error) {
 func (qr *QRCode) Encode(title, data string) error {
 	img, err := qr.writer.Encode(data, gozxing.BarcodeFormat_QR_CODE, qr.imageSize, qr.imageSize, nil)
 	if err != nil {
-		return errors.Errorf("failed to encode data: %w", err)
+		return errors.Errorf("encode data: %w", err)
 	}
 
 	size := img.Bounds().Size()

--- a/common/image/qrsignature/signature.go
+++ b/common/image/qrsignature/signature.go
@@ -67,7 +67,7 @@ func (sig Signature) Encode(img image.Image) (image.Image, error) {
 
 	sigData := new(bytes.Buffer)
 	if err := png.Encode(sigData, sigImg); err != nil {
-		return nil, errors.Errorf("failed to encode signature to data: %w", err)
+		return nil, errors.Errorf("encode signature: %w", err)
 	}
 
 	if sigW := sigImg.Bounds().Dx(); sigW > img.Bounds().Dx() {
@@ -88,7 +88,7 @@ func (sig Signature) Decode(img image.Image) error {
 
 	img, _, err := image.Decode(bytes.NewReader(data))
 	if err != nil {
-		return errors.Errorf("failed to decode image from data: %w", err)
+		return errors.Errorf("decode image: %w", err)
 	}
 
 	if err := sig.metadata.qrCode.Load(img); err != nil {

--- a/common/log/hooks/file.go
+++ b/common/log/hooks/file.go
@@ -44,7 +44,7 @@ func (hook *FileHook) SetMaxSize(maxSize int) {
 func (hook *FileHook) Fire(entry *logrus.Entry) error {
 	msg, err := hook.formatter.Format(entry)
 	if err != nil {
-		return fmt.Errorf("failed to generate string for entry, %s", err)
+		return fmt.Errorf("generate string for entry: %s", err)
 	}
 
 	_, err = hook.fileLogger.Write(msg)

--- a/common/net/credentials/alts/handshaker/handshaker.go
+++ b/common/net/credentials/alts/handshaker/handshaker.go
@@ -214,7 +214,7 @@ func (s *altsHandshaker) writeHandshake(value interface{}) error {
 	}
 
 	if err := writer.Flush(); err != nil {
-		return fmt.Errorf("failed to flush, err: %s", err)
+		return fmt.Errorf("flush: %s", err)
 	}
 	return nil
 }
@@ -256,7 +256,7 @@ func (s *altsHandshaker) doClientHandshake(ctx context.Context, secClient alts.S
 	// generate the private and public key for client
 	priv, pub, ok := curve.GenerateKeys()
 	if !ok {
-		return errors.New("failed to generate keys")
+		return errors.New("generate keys failed")
 	}
 
 	dataSign := make([]byte, challengeSize+ED448PubKeySize)
@@ -264,8 +264,7 @@ func (s *altsHandshaker) doClientHandshake(ctx context.Context, secClient alts.S
 	dataSign = append(dataSign, challengeB...)
 	signature, err := secClient.Sign(ctx, dataSign, secInfo.PastelID, secInfo.PassPhrase, secInfo.Algorithm)
 	if err != nil {
-		log.WithContext(ctx).WithError(err).Error("failed to generate signature")
-		return fmt.Errorf("failed to generate signature: %w", err)
+		return fmt.Errorf("generate signature: %w", err)
 	}
 
 	request := kexExchangeRequest{
@@ -289,7 +288,7 @@ func (s *altsHandshaker) doClientHandshake(ctx context.Context, secClient alts.S
 	dataVerify = append(dataVerify, challengeA...)
 	if ok, err := secClient.Verify(ctx, dataVerify, string(response.Signature), response.PastelID, secInfo.Algorithm); err != nil || !ok {
 		log.WithContext(ctx).WithError(err).Error("failed to verify server public key")
-		return fmt.Errorf("failed to verify server public key: %w", err)
+		return fmt.Errorf("verify server public key: %w", err)
 	}
 
 	// compute the secret key for connection
@@ -298,7 +297,7 @@ func (s *altsHandshaker) doClientHandshake(ctx context.Context, secClient alts.S
 	// derive key
 	derivedKey, err := keyDerive([]byte(secret[:]))
 	if err != nil {
-		return fmt.Errorf("failed to derive key: %w", err)
+		return fmt.Errorf("derive key: %w", err)
 	}
 	subkeyLen, ok := recordKeyLen[s.protocol]
 	if !ok {
@@ -361,14 +360,14 @@ func (s *altsHandshaker) doServerHandshake(ctx context.Context, secClient alts.S
 	dataVerify = append(dataVerify, challengeB...)
 	if ok, err := secClient.Verify(ctx, dataVerify, string(request.Signature), request.PastelID, secInfo.Algorithm); err != nil || !ok {
 		log.WithContext(ctx).WithError(err).Error("failed to verify client public key")
-		return fmt.Errorf("failed to verify client public key: %w", err)
+		return fmt.Errorf("verify client public key: %w", err)
 	}
 
 	curve := ed448.NewCurve()
 	// generate the private key and public key for server
 	priv, pub, ok := curve.GenerateKeys()
 	if !ok {
-		return errors.New("failed to generate keys")
+		return errors.New("generate keys failed")
 	}
 
 	dataSign := make([]byte, challengeSize+ED448PubKeySize)
@@ -377,7 +376,7 @@ func (s *altsHandshaker) doServerHandshake(ctx context.Context, secClient alts.S
 	signature, err := secClient.Sign(ctx, dataSign, secInfo.PastelID, secInfo.PassPhrase, secInfo.Algorithm)
 	if err != nil {
 		log.WithContext(ctx).WithError(err).Error("failed to generate signature")
-		return fmt.Errorf("failed to generate signature: %w", err)
+		return fmt.Errorf("generate signature: %w", err)
 	}
 
 	// compute the secret key for connection
@@ -386,7 +385,7 @@ func (s *altsHandshaker) doServerHandshake(ctx context.Context, secClient alts.S
 	// derive key
 	derivedKey, err := keyDerive([]byte(secret[:]))
 	if err != nil {
-		return fmt.Errorf("failed to derive key: %w", err)
+		return fmt.Errorf("derive key: %w", err)
 	}
 	subkeyLen, ok := recordKeyLen[s.protocol]
 	if !ok {

--- a/common/net/credentials/alts_test.go
+++ b/common/net/credentials/alts_test.go
@@ -42,7 +42,7 @@ func (c *FakePastelClient) Sign(_ context.Context, data []byte, pastelID, _ stri
 	c.signatures[pastelID] = signature
 	c.data[pastelID] = data
 	if c.errorSign {
-		return nil, fmt.Errorf("failed in signing")
+		return nil, fmt.Errorf("signing failed")
 	}
 	return signature, nil
 }
@@ -58,7 +58,7 @@ func (c *FakePastelClient) Verify(_ context.Context, data []byte, signature, pas
 	}
 
 	if c.errorVerify {
-		return false, fmt.Errorf("failed in verifying")
+		return false, fmt.Errorf("verifying failed")
 	}
 	return ret, nil
 }

--- a/common/storage/fs/file.go
+++ b/common/storage/fs/file.go
@@ -28,7 +28,7 @@ func (fs *FS) Open(filename string) (storage.File, error) {
 
 	file, err := os.Open(filename)
 	if err != nil {
-		return nil, errors.Errorf("failed to open file %q: %w", filename, err)
+		return nil, errors.Errorf("open file %q: %w", filename, err)
 	}
 	return file, nil
 }
@@ -45,7 +45,7 @@ func (fs *FS) Create(filename string) (storage.File, error) {
 
 	file, err := os.Create(filename)
 	if err != nil {
-		return nil, errors.Errorf("failed to create file %q: %w", filename, err)
+		return nil, errors.Errorf("create file %q: %w", filename, err)
 	}
 	return file, nil
 }
@@ -57,7 +57,7 @@ func (fs *FS) Remove(filename string) error {
 	log.WithPrefix(logPrefix).Debugf("Remove file %q", filename)
 
 	if err := os.Remove(filename); err != nil {
-		return errors.Errorf("failed to remove file %q: %w", filename, err)
+		return errors.Errorf("remove file %q: %w", filename, err)
 	}
 	return nil
 }
@@ -74,7 +74,7 @@ func (fs *FS) Rename(oldname, newname string) error {
 	log.WithPrefix(logPrefix).Debugf("Rename file %q to %q", oldname, newname)
 
 	if err := os.Rename(oldname, newname); err != nil {
-		return errors.Errorf("failed to rename file %q to %q: %w", oldname, newname, err)
+		return errors.Errorf("rename file %q to %q: %w", oldname, newname, err)
 	}
 	return nil
 }

--- a/dupedetection/ddclient/ddclient.go
+++ b/dupedetection/ddclient/ddclient.go
@@ -79,7 +79,7 @@ func createInputDDFile(base string, data []byte, format string) (string, error) 
 	err := writeFile(filePath, data)
 
 	if err != nil {
-		return "", errors.Errorf("failed to write data to %s: %w", filePath, err)
+		return "", errors.Errorf("write data to %s: %w", filePath, err)
 	}
 
 	return filePath, nil
@@ -93,7 +93,7 @@ func (ddClient *ddServerClientImpl) callImageRarenessScore(ctx context.Context, 
 
 	inputPath, err := createInputDDFile(ddClient.config.DDFilesDir, img, format)
 	if err != nil {
-		return nil, errors.Errorf("failed to create input file: %w", err)
+		return nil, errors.Errorf("create input file: %w", err)
 	}
 
 	req := pb.RarenessScoreRequest{
@@ -105,7 +105,7 @@ func (ddClient *ddServerClientImpl) callImageRarenessScore(ctx context.Context, 
 
 	res, err := client.ImageRarenessScore(ctx, &req)
 	if err != nil {
-		return nil, errors.Errorf("failed to send request: %w", err)
+		return nil, errors.Errorf("send request: %w", err)
 	}
 
 	/*
@@ -160,7 +160,7 @@ func (ddClient *ddServerClientImpl) ImageRarenessScore(ctx context.Context, img 
 	ddServerAddress := fmt.Sprint(ddClient.config.Host, ":", ddClient.config.Port)
 	conn, err := baseClient.Connect(ctx, ddServerAddress)
 	if err != nil {
-		return nil, errors.Errorf("failed to connect to dd-server  %w", err)
+		return nil, errors.Errorf("connect to dd-server  %w", err)
 	}
 
 	defer conn.Close()

--- a/dupedetection/ddscan/service.go
+++ b/dupedetection/ddscan/service.go
@@ -78,7 +78,7 @@ func (s *service) Run(ctx context.Context) error {
 			if utils.IsContextErr(err) {
 				return err
 			}
-			log.WithContext(ctx).WithError(err).Error("failed to start dd-scan service, retrying.")
+			log.WithContext(ctx).WithError(err).Error("Failed to start dd-scan service, retrying.")
 		} else {
 			return nil
 		}
@@ -90,7 +90,7 @@ func (s *service) run(ctx context.Context) error {
 	defer s.db.Close()
 
 	if err := s.waitSynchronization(ctx); err != nil {
-		log.WithContext(ctx).WithError(err).Error("failed to initial wait synchronization")
+		log.WithContext(ctx).WithError(err).Error("Failed to initial wait synchronization")
 	} else {
 		s.isMasterNodeSynced = true
 	}
@@ -124,7 +124,7 @@ func (s *service) run(ctx context.Context) error {
 func (s *service) checkSynchronized(ctx context.Context) error {
 	st, err := s.pastelClient.MasterNodeStatus(ctx)
 	if err != nil {
-		return errors.Errorf("get MasterNodeStatus() failed: %w", err)
+		return errors.Errorf("getMasterNodeStatus: %w", err)
 	}
 
 	if st == nil {
@@ -168,7 +168,7 @@ func (s *service) waitSynchronization(ctx context.Context) error {
 func (s *service) getLatestFingerprint(ctx context.Context) (*dupeDetectionFingerprints, error) {
 	row, err := s.db.QueryStringStmt(getLatestFingerprintStatement)
 	if err != nil {
-		return nil, errors.Errorf("failed to query, err: %w", err)
+		return nil, errors.Errorf("query: %w", err)
 	}
 
 	if len(row) != 0 && len(row[0].Values) == 0 {
@@ -217,12 +217,12 @@ func (s *service) getLatestFingerprint(ctx context.Context) (*dupeDetectionFinge
 
 	b, err := json.Marshal(resultStr)
 	if err != nil {
-		return nil, errors.Errorf("failed to JSON marshal value, err: %w", err)
+		return nil, errors.Errorf("marshal output: %w", err)
 	}
 
 	ddFingerprint := &dupeDetectionFingerprints{}
 	if err := json.Unmarshal(b, ddFingerprint); err != nil {
-		return nil, errors.Errorf("failed to JSON unmarshal, err: %w", err)
+		return nil, errors.Errorf("unmarshal json: %w", err)
 	}
 
 	return ddFingerprint, nil
@@ -234,7 +234,7 @@ func (s *service) storeFingerprint(ctx context.Context, input *dupeDetectionFing
 		m := mat.NewDense(len(v), 1, v)
 		f := bytes.NewBuffer(nil)
 		if err := npyio.Write(f, m); err != nil {
-			return nil, errors.Errorf("failed to encode to npy, err: %w", err)
+			return nil, errors.Errorf("encode to npy: %w", err)
 		}
 		return f.Bytes(), nil
 	}
@@ -312,7 +312,7 @@ func (s *service) runTask(ctx context.Context) error {
 
 	nftRegTickets, err := s.pastelClient.RegTickets(ctx)
 	if err != nil {
-		return errors.Errorf("failed to get registered ticket, err: %w", err)
+		return errors.Errorf("get registered ticket: %w", err)
 	}
 
 	if len(nftRegTickets) == 0 {
@@ -321,7 +321,7 @@ func (s *service) runTask(ctx context.Context) error {
 
 	lastestFp, err := s.getLatestFingerprint(ctx)
 	if err != nil {
-		return errors.Errorf("failed to get lastest fingerprint, err: %w", err)
+		return errors.Errorf("get lastest fingerprint: %w", err)
 	}
 
 	for i := 0; i < len(nftRegTickets); i++ {
@@ -400,7 +400,7 @@ func (s *service) getRecordCount(ctx context.Context) (int64, error) {
 	statement := getNumberOfFingerprintsStatement
 	rows, err := s.db.QueryStringStmt(statement)
 	if err != nil {
-		return 0, errors.Errorf("query failed: %w", err)
+		return 0, errors.Errorf("query: %w", err)
 	}
 	row := rows[0]
 
@@ -427,14 +427,14 @@ func (s *service) Stats(ctx context.Context) (map[string]interface{}, error) {
 	// Get last inserted item
 	lastItem, err := s.getLatestFingerprint(ctx)
 	if err != nil {
-		return nil, errors.Errorf("failed to getLatestFingerprint(): %w", err)
+		return nil, errors.Errorf("getLatestFingerprint: %w", err)
 	}
 	stats["last_insert_time"] = lastItem.DatetimeFingerprintAddedToDatabase
 
 	// Get total of records
 	record_count, err := s.getRecordCount(ctx)
 	if err != nil {
-		return nil, errors.Errorf("failed to getRecordCount(): %w", err)
+		return nil, errors.Errorf("getRecordCount: %w", err)
 	}
 	stats["record_count"] = record_count
 
@@ -444,12 +444,12 @@ func (s *service) Stats(ctx context.Context) (map[string]interface{}, error) {
 // NewService return a new Service instance
 func NewService(config *Config, pastelClient pastel.Client, p2pClient p2p.Client) (Service, error) {
 	if _, err := os.Stat(config.DataFile); os.IsNotExist(err) {
-		return nil, errors.Errorf("database dd service not found, err: %w", err)
+		return nil, errors.Errorf("database dd service not found: %w", err)
 	}
 
 	db, err := db.Open(config.DataFile)
 	if err != nil {
-		return nil, errors.Errorf("failed to open dd-service database, err: %w", err)
+		return nil, errors.Errorf("open dd-service database: %w", err)
 	}
 
 	return &service{

--- a/p2p/kademlia/message.go
+++ b/p2p/kademlia/message.go
@@ -104,7 +104,7 @@ func decode(conn io.Reader) (*Message, error) {
 	// parse the length of message
 	length, err := binary.ReadUvarint(bytes.NewBuffer(header))
 	if err != nil {
-		return nil, errors.Errorf("parse header length failed: %w", err)
+		return nil, errors.Errorf("parse header length: %w", err)
 	}
 	log.Debugf("message length %d", length)
 

--- a/p2p/kademlia/store/db/db.go
+++ b/p2p/kademlia/store/db/db.go
@@ -100,7 +100,7 @@ func (s *Badger) Retrieve(ctx context.Context, key []byte) ([]byte, error) {
 		return nil, errors.Errorf("badger view: %w", err)
 	}
 
-	log.WithContext(ctx).Infof("retrieve key: %s", base58.Encode(key))
+	//log.WithContext(ctx).Infof("retrieve key: %s", base58.Encode(key))
 	return value, nil
 }
 

--- a/p2p/kademlia/store/db/db.go
+++ b/p2p/kademlia/store/db/db.go
@@ -57,7 +57,7 @@ func NewStore(ctx context.Context, dataDir string) (*Badger, error) {
 
 // Store will store a key/value pair for the local node with the given
 // replication and expiration times.
-func (s *Badger) Store(ctx context.Context, key []byte, value []byte, replication time.Time) error {
+func (s *Badger) Store(_ context.Context, key []byte, value []byte, replication time.Time) error {
 	if err := s.db.Update(func(txn *badger.Txn) error {
 		// set the key/value to badger
 		if err := txn.Set(key, value); err != nil {
@@ -76,12 +76,11 @@ func (s *Badger) Store(ctx context.Context, key []byte, value []byte, replicatio
 		return errors.Errorf("badger update: %v, %w", base58.Encode(key), err)
 	}
 
-	log.WithContext(ctx).Infof("store key: %s", base58.Encode(key))
 	return nil
 }
 
 // Retrieve the local key/value from store
-func (s *Badger) Retrieve(ctx context.Context, key []byte) ([]byte, error) {
+func (s *Badger) Retrieve(_ context.Context, key []byte) ([]byte, error) {
 	var value []byte
 	// find key from badger
 	if err := s.db.View(func(txn *badger.Txn) error {
@@ -100,7 +99,6 @@ func (s *Badger) Retrieve(ctx context.Context, key []byte) ([]byte, error) {
 		return nil, errors.Errorf("badger view: %w", err)
 	}
 
-	//log.WithContext(ctx).Infof("retrieve key: %s", base58.Encode(key))
 	return value, nil
 }
 

--- a/p2p/kademlia/store/mem/mem.go
+++ b/p2p/kademlia/store/mem/mem.go
@@ -4,9 +4,6 @@ import (
 	"context"
 	"sync"
 	"time"
-
-	"github.com/btcsuite/btcutil/base58"
-	"github.com/pastelnetwork/gonode/common/log"
 )
 
 // Store is a simple in-memory key/value store used for unit testing
@@ -34,19 +31,18 @@ func (s *Store) KeysForReplication(_ context.Context) [][]byte {
 
 // Store will store a key/value pair for the local node with the given
 // replication and expiration times.
-func (s *Store) Store(ctx context.Context, key []byte, value []byte, replication time.Time) error {
+func (s *Store) Store(_ context.Context, key []byte, value []byte, replication time.Time) error {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
 	s.replications[string(key)] = replication
 	s.data[string(key)] = value
 
-	log.WithContext(ctx).Debugf("store key: %s", base58.Encode(key))
 	return nil
 }
 
 // Retrieve will return the local key/value if it exists
-func (s *Store) Retrieve(ctx context.Context, key []byte) ([]byte, error) {
+func (s *Store) Retrieve(_ context.Context, key []byte) ([]byte, error) {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 
@@ -55,7 +51,6 @@ func (s *Store) Retrieve(ctx context.Context, key []byte) ([]byte, error) {
 		return nil, nil
 	}
 
-	//log.WithContext(ctx).Debugf("retrieve key: %s", base58.Encode(key))
 	return value, nil
 }
 

--- a/p2p/kademlia/store/mem/mem.go
+++ b/p2p/kademlia/store/mem/mem.go
@@ -55,7 +55,7 @@ func (s *Store) Retrieve(ctx context.Context, key []byte) ([]byte, error) {
 		return nil, nil
 	}
 
-	log.WithContext(ctx).Debugf("retrieve key: %s", base58.Encode(key))
+	//log.WithContext(ctx).Debugf("retrieve key: %s", base58.Encode(key))
 	return value, nil
 }
 

--- a/pastel/fingerprint.go
+++ b/pastel/fingerprint.go
@@ -3,10 +3,11 @@ package pastel
 import (
 	"bytes"
 	"encoding/binary"
-	"github.com/DataDog/zstd"
 	"math"
 	"strings"
 	"unsafe"
+
+	"github.com/DataDog/zstd"
 
 	"github.com/pastelnetwork/gonode/common/errors"
 )
@@ -80,12 +81,12 @@ func CompareFingerPrintAndScore(lhs *FingerAndScores, rhs *FingerAndScores) erro
 
 	lhsFingerprint, err := zstd.Decompress(nil, lhs.ZstdCompressedFingerprint)
 	if err != nil {
-		return errors.Errorf("failed to decompress lhs fingerprint: %w", err)
+		return errors.Errorf("decompress lhs fingerprint: %w", err)
 	}
 
 	rhsFingerprint, err := zstd.Decompress(nil, rhs.ZstdCompressedFingerprint)
 	if err != nil {
-		return errors.Errorf("failed to decompress rhs fingerprint: %w", err)
+		return errors.Errorf("decompress rhs fingerprint: %w", err)
 	}
 
 	if !bytes.Equal(lhsFingerprint, rhsFingerprint) {

--- a/pastel/reg_ticket.go
+++ b/pastel/reg_ticket.go
@@ -166,7 +166,7 @@ type internalNFTTicket struct {
 func EncodeNFTTicket(ticket *NFTTicket) ([]byte, error) {
 	appTicket, err := json.Marshal(ticket.AppTicketData)
 	if err != nil {
-		return nil, errors.Errorf("failed to marshal app ticket data: %w", err)
+		return nil, errors.Errorf("marshal app ticket data: %w", err)
 	}
 
 	// NFTTicket is Pastel Art Ticket
@@ -183,7 +183,7 @@ func EncodeNFTTicket(ticket *NFTTicket) ([]byte, error) {
 
 	b, err := json.Marshal(nftTicket)
 	if err != nil {
-		return nil, errors.Errorf("failed to marshal nft ticket: %w", err)
+		return nil, errors.Errorf("marshal nft ticket: %w", err)
 	}
 
 	return b, nil
@@ -195,14 +195,14 @@ func DecodeNFTTicket(b []byte) (*NFTTicket, error) {
 	err := json.Unmarshal(b, &res)
 
 	if err != nil {
-		return nil, errors.Errorf("failed to unmarshal nft ticket: %w", err)
+		return nil, errors.Errorf("unmarshal nft ticket: %w", err)
 	}
 
 	appTicket := AppTicket{}
 
 	err = json.Unmarshal(res.AppTicket, &appTicket)
 	if err != nil {
-		return nil, errors.Errorf("failed to unmarshal app ticket data: %w", err)
+		return nil, errors.Errorf("unmarshal app ticket data: %w", err)
 	}
 
 	return &NFTTicket{
@@ -245,7 +245,7 @@ func EncodeSignatures(signatures TicketSignatures) ([]byte, error) {
 	b, err := json.Marshal(signatures)
 
 	if err != nil {
-		return nil, errors.Errorf("failed to marshal signatures: %w", err)
+		return nil, errors.Errorf("marshal signatures: %w", err)
 	}
 
 	return b, nil

--- a/raptorq/node/grpc/raptorq.go
+++ b/raptorq/node/grpc/raptorq.go
@@ -45,7 +45,7 @@ func readFileLines(path string) ([]string, error) {
 	b, err := ioutil.ReadFile(path)
 
 	if err != nil {
-		return nil, errors.Errorf("failed to read file: %w", err)
+		return nil, errors.Errorf("read file: %w", err)
 	}
 	return strings.Split(string(b), "\n"), nil
 }
@@ -68,14 +68,14 @@ func createInputEncodeFile(base string, data []byte) (taskPath string, inputFile
 	taskPath, err = createTaskFolder(base)
 
 	if err != nil {
-		return "", "", errors.Errorf("failed to create task folder: %w", err)
+		return "", "", errors.Errorf("create task folder: %w", err)
 	}
 
 	inputFile = filepath.Join(taskPath, inputEncodeFileName)
 	err = writeFile(inputFile, data)
 
 	if err != nil {
-		return "", "", errors.Errorf("failed to create task folder: %w", err)
+		return "", "", errors.Errorf("write file: %w", err)
 	}
 
 	return taskPath, inputFile, nil
@@ -85,7 +85,7 @@ func createInputDecodeSymbols(base string, symbols map[string][]byte) (path stri
 	path, err = createTaskFolder(base, symbolFileSubdir)
 
 	if err != nil {
-		return "", errors.Errorf("failed to create task folder: %w", err)
+		return "", errors.Errorf("create task folder: %w", err)
 	}
 
 	for id, data := range symbols {
@@ -93,7 +93,7 @@ func createInputDecodeSymbols(base string, symbols map[string][]byte) (path stri
 		err = writeFile(symbolFile, data)
 
 		if err != nil {
-			return "", errors.Errorf("failed to create symbol file: %w", err)
+			return "", errors.Errorf("write symbol file: %w", err)
 		}
 	}
 
@@ -106,7 +106,7 @@ func scanSymbolIDFiles(dirPath string) (map[string][]string, error) {
 
 	err := filepath.Walk(dirPath, func(path string, info fs.FileInfo, err error) error {
 		if err != nil {
-			return errors.Errorf("failed to scan a path %s: %w", path, err)
+			return errors.Errorf("scan a path %s: %w", path, err)
 		}
 
 		if info.IsDir() {
@@ -118,7 +118,7 @@ func scanSymbolIDFiles(dirPath string) (map[string][]string, error) {
 
 		lines, err := readFileLines(path)
 		if err != nil {
-			return errors.Errorf("failed to read file %s: %w", path, err)
+			return errors.Errorf("read file %s: %w", path, err)
 		}
 
 		filesMap[fileID] = lines
@@ -139,7 +139,7 @@ func scanSymbolFiles(dirPath string) (map[string][]byte, error) {
 
 	err := filepath.Walk(dirPath, func(path string, info fs.FileInfo, err error) error {
 		if err != nil {
-			return errors.Errorf("failed to scan a path %s: %w", path, err)
+			return errors.Errorf("scan a path %s: %w", path, err)
 		}
 
 		if info.IsDir() {
@@ -151,7 +151,7 @@ func scanSymbolFiles(dirPath string) (map[string][]byte, error) {
 
 		data, err := readFile(path)
 		if err != nil {
-			return errors.Errorf("failed to read file %s: %w", path, err)
+			return errors.Errorf("read file %s: %w", path, err)
 		}
 
 		filesMap[fileID] = data
@@ -176,7 +176,7 @@ func (service *raptorQ) Encode(ctx context.Context, data []byte) (*node.Encode, 
 
 	_, inputPath, err := createInputEncodeFile(service.config.RqFilesDir, data)
 	if err != nil {
-		return nil, errors.Errorf("failed to create input file: %w", err)
+		return nil, errors.Errorf("create input file: %w", err)
 	}
 
 	req := pb.EncodeRequest{
@@ -185,12 +185,12 @@ func (service *raptorQ) Encode(ctx context.Context, data []byte) (*node.Encode, 
 
 	res, err := service.client.Encode(ctx, &req)
 	if err != nil {
-		return nil, errors.Errorf("failed to send request: %w", err)
+		return nil, errors.Errorf("send encode request: %w", err)
 	}
 
 	fileMap, err := scanSymbolFiles(res.Path)
 	if err != nil {
-		return nil, errors.Errorf("failed to scan symbol folder %s: %w", res.Path, err)
+		return nil, errors.Errorf("scan symbol folder %s: %w", res.Path, err)
 	}
 
 	if len(fileMap) != int(res.SymbolsCount) {
@@ -215,7 +215,7 @@ func (service *raptorQ) EncodeInfo(ctx context.Context, data []byte, copies uint
 
 	_, inputPath, err := createInputEncodeFile(service.config.RqFilesDir, data)
 	if err != nil {
-		return nil, errors.Errorf("failed to create input file: %w", err)
+		return nil, errors.Errorf("create input file: %w", err)
 	}
 
 	req := pb.EncodeMetaDataRequest{
@@ -227,14 +227,14 @@ func (service *raptorQ) EncodeInfo(ctx context.Context, data []byte, copies uint
 
 	res, err := service.client.EncodeMetaData(ctx, &req)
 	if err != nil {
-		return nil, errors.Errorf("failed to send request: %w", err)
+		return nil, errors.Errorf("send encode info request: %w", err)
 	}
 
 	// scan return symbol Id files
 	symbolCnt := res.SymbolsCount
 	filesMap, err := scanSymbolIDFiles(res.Path)
 	if err != nil {
-		return nil, errors.Errorf("failed to scan symbol id files folder %s: %w", res.Path, err)
+		return nil, errors.Errorf("scan symbol id files folder %s: %w", res.Path, err)
 	}
 
 	if len(filesMap) != int(copies) {
@@ -276,7 +276,7 @@ func (service *raptorQ) Decode(ctx context.Context, encodeInfo *node.Encode) (*n
 
 	symbolsDir, err := createInputDecodeSymbols(service.config.RqFilesDir, encodeInfo.Symbols)
 	if err != nil {
-		return nil, errors.Errorf("failed to create symbol files: %w", err)
+		return nil, errors.Errorf("create symbol files: %w", err)
 	}
 
 	req := pb.DecodeRequest{
@@ -286,12 +286,12 @@ func (service *raptorQ) Decode(ctx context.Context, encodeInfo *node.Encode) (*n
 
 	res, err := service.client.Decode(ctx, &req)
 	if err != nil {
-		return nil, errors.Errorf("failed to send request: %w", err)
+		return nil, errors.Errorf("send decode request: %w", err)
 	}
 
 	restoredFile, err := readFile(res.Path)
 	if err != nil {
-		return nil, errors.Errorf("failed to read file: %w, Path: %s", err, res.Path)
+		return nil, errors.Errorf("read file: %w, Path: %s", err, res.Path)
 	}
 
 	output := &node.Decode{

--- a/supernode/healthcheck/pastel_stats.go
+++ b/supernode/healthcheck/pastel_stats.go
@@ -26,21 +26,21 @@ func (client *PastelStatsClient) Stats(ctx context.Context) (map[string]interfac
 	// Get master top nodes
 	topNodes, err := client.pastelClient.MasterNodesTop(ctx)
 	if err != nil {
-		return nil, errors.Errorf("failed to MasterNodesTop(): %w", err)
+		return nil, errors.Errorf("call MasterNodesTop(): %w", err)
 	}
 	stats["master_top_nodes"] = topNodes
 
 	// Get masternode status
 	masternodeStatus, err := client.pastelClient.MasterNodeStatus(ctx)
 	if err != nil {
-		return nil, errors.Errorf("failed to MasterNodeStatus(): %w", err)
+		return nil, errors.Errorf("call MasterNodeStatus(): %w", err)
 	}
 	stats["master_node_status"] = masternodeStatus
 
 	// get current block height
 	blockHeight, err := client.pastelClient.GetBlockCount(ctx)
 	if err != nil {
-		return nil, errors.Errorf("failed to GetBlockCount(): %w", err)
+		return nil, errors.Errorf("call GetBlockCount(): %w", err)
 	}
 	stats["block_height"] = blockHeight
 

--- a/supernode/healthcheck/stats_mngr.go
+++ b/supernode/healthcheck/stats_mngr.go
@@ -61,7 +61,7 @@ func (mngr *StatsMngr) updateStats(ctx context.Context) (map[string]interface{},
 	for id, client := range mngr.clients {
 		subStats, err := client.Stats(ctx)
 		if err != nil {
-			return nil, errors.Errorf("failed to get stats of %s: %w", id, err)
+			return nil, errors.Errorf("get stats of %s: %w", id, err)
 		}
 		stats[id] = subStats
 	}

--- a/supernode/node/grpc/client/client.go
+++ b/supernode/node/grpc/client/client.go
@@ -36,7 +36,7 @@ func (client *client) Connect(ctx context.Context, address string) (node.Connect
 		grpc.WithBlock(),
 	)
 	if err != nil {
-		return nil, errors.Errorf("fail to dial: %w", err).WithField("address", address)
+		return nil, errors.Errorf("dial address %s: %w", address, err)
 	}
 	log.WithContext(ctx).Debugf("Connected to %s", address)
 

--- a/supernode/node/grpc/client/process_userdata.go
+++ b/supernode/node/grpc/client/process_userdata.go
@@ -35,7 +35,7 @@ func (service *processUserdata) Session(ctx context.Context, nodeID, sessID stri
 
 	stream, err := service.client.Session(ctx)
 	if err != nil {
-		return errors.Errorf("failed to open Health stream: %w", err)
+		return errors.Errorf("open Health stream: %w", err)
 	}
 
 	req := &pb.MDLSessionRequest{
@@ -44,7 +44,7 @@ func (service *processUserdata) Session(ctx context.Context, nodeID, sessID stri
 	log.WithContext(ctx).WithField("req", req).Debugf("Session request")
 
 	if err := stream.Send(req); err != nil {
-		return errors.Errorf("failed to send Session request: %w", err)
+		return errors.Errorf("send Session request: %w", err)
 	}
 
 	resp, err := stream.Recv()
@@ -56,7 +56,7 @@ func (service *processUserdata) Session(ctx context.Context, nodeID, sessID stri
 		case codes.Canceled, codes.Unavailable:
 			return nil
 		}
-		return errors.Errorf("failed to receive Session response: %w", err)
+		return errors.Errorf("receive Session response: %w", err)
 	}
 	log.WithContext(ctx).WithField("resp", resp).Debugf("Session response")
 

--- a/supernode/node/grpc/client/register_artwork.go
+++ b/supernode/node/grpc/client/register_artwork.go
@@ -34,7 +34,7 @@ func (service *registerArtwork) Session(ctx context.Context, nodeID, sessID stri
 
 	stream, err := service.client.Session(ctx)
 	if err != nil {
-		return errors.Errorf("failed to open Health stream: %w", err)
+		return errors.Errorf("open Health stream: %w", err)
 	}
 
 	req := &pb.SessionRequest{
@@ -43,7 +43,7 @@ func (service *registerArtwork) Session(ctx context.Context, nodeID, sessID stri
 	log.WithContext(ctx).WithField("req", req).Debugf("Session request")
 
 	if err := stream.Send(req); err != nil {
-		return errors.Errorf("failed to send Session request: %w", err)
+		return errors.Errorf("send Session request: %w", err)
 	}
 
 	resp, err := stream.Recv()
@@ -55,7 +55,7 @@ func (service *registerArtwork) Session(ctx context.Context, nodeID, sessID stri
 		case codes.Canceled, codes.Unavailable:
 			return nil
 		}
-		return errors.Errorf("failed to receive Session response: %w", err)
+		return errors.Errorf("receive Session response: %w", err)
 	}
 	log.WithContext(ctx).WithField("resp", resp).Debugf("Session response")
 

--- a/supernode/node/grpc/server/server.go
+++ b/supernode/node/grpc/server/server.go
@@ -37,7 +37,7 @@ func (server *Server) Run(ctx context.Context) error {
 	addresses := strings.Split(server.config.ListenAddresses, ",")
 	grpcServer := server.grpcServer(ctx)
 	if grpcServer == nil {
-		return fmt.Errorf("failed to initialize grpc server")
+		return fmt.Errorf("initialize grpc server failed")
 	}
 
 	for _, address := range addresses {
@@ -54,7 +54,7 @@ func (server *Server) Run(ctx context.Context) error {
 func (server *Server) listen(ctx context.Context, address string, grpcServer *grpc.Server) (err error) {
 	listen, err := net.Listen("tcp", address)
 	if err != nil {
-		return errors.Errorf("failed to listen: %w", err).WithField("address", address)
+		return errors.Errorf("listen: %w", err).WithField("address", address)
 	}
 
 	errCh := make(chan error, 1)
@@ -62,7 +62,7 @@ func (server *Server) listen(ctx context.Context, address string, grpcServer *gr
 		defer errors.Recover(func(recErr error) { err = recErr })
 		log.WithContext(ctx).Infof("gRPC server listening on %q", address)
 		if err := grpcServer.Serve(listen); err != nil {
-			errCh <- errors.Errorf("failed to serve: %w", err).WithField("address", address)
+			errCh <- errors.Errorf("serve: %w", err).WithField("address", address)
 		}
 	}()
 

--- a/supernode/node/grpc/server/services/healthcheck/healthcheck.go
+++ b/supernode/node/grpc/server/services/healthcheck/healthcheck.go
@@ -25,12 +25,12 @@ type HealthCheck struct {
 func (service *HealthCheck) Ping(ctx context.Context, _ *pb.PingRequest) (*pb.PingReply, error) {
 	stats, err := service.Stats(ctx)
 	if err != nil {
-		return &pb.PingReply{Reply: ""}, errors.Errorf("failed to Stats(): %w", err)
+		return &pb.PingReply{Reply: ""}, errors.Errorf("Stats(): %w", err)
 	}
 
 	jsonData, err := json.Marshal(stats)
 	if err != nil {
-		return &pb.PingReply{Reply: ""}, errors.Errorf("failed to Marshal(): %w", err)
+		return &pb.PingReply{Reply: ""}, errors.Errorf("Marshal(): %w", err)
 	}
 
 	// echos received message

--- a/supernode/node/grpc/server/services/supernode/process_userdata.go
+++ b/supernode/node/grpc/server/services/supernode/process_userdata.go
@@ -56,7 +56,7 @@ func (service *ProcessUserdata) Session(stream pb.ProcessUserdata_SessionServer)
 
 	req, err := stream.Recv()
 	if err != nil {
-		return errors.Errorf("failed to receieve handshake request: %w", err)
+		return errors.Errorf("receive handshake request: %w", err)
 	}
 	log.WithContext(ctx).WithField("req", req).Debugf("Session request")
 
@@ -68,7 +68,7 @@ func (service *ProcessUserdata) Session(stream pb.ProcessUserdata_SessionServer)
 		SessID: task.ID(),
 	}
 	if err := stream.Send(resp); err != nil {
-		return errors.Errorf("failed to send handshake response: %w", err)
+		return errors.Errorf("send handshake response: %w", err)
 	}
 	log.WithContext(ctx).WithField("resp", resp).Debugf("Session response")
 

--- a/supernode/node/grpc/server/services/supernode/register_artwork.go
+++ b/supernode/node/grpc/server/services/supernode/register_artwork.go
@@ -48,7 +48,7 @@ func (service *RegisterArtwork) Session(stream pb.RegisterArtwork_SessionServer)
 
 	req, err := stream.Recv()
 	if err != nil {
-		return errors.Errorf("failed to receive handshake request: %w", err)
+		return errors.Errorf("receive handshake request: %w", err)
 	}
 	log.WithContext(ctx).WithField("req", req).Debugf("Session request")
 
@@ -60,7 +60,7 @@ func (service *RegisterArtwork) Session(stream pb.RegisterArtwork_SessionServer)
 		SessID: task.ID(),
 	}
 	if err := stream.Send(resp); err != nil {
-		return errors.Errorf("failed to send handshake response: %w", err)
+		return errors.Errorf("send handshake response: %w", err)
 	}
 	log.WithContext(ctx).WithField("resp", resp).Debugf("Session response")
 
@@ -87,7 +87,7 @@ func (service *RegisterArtwork) SendArtTicketSignature(ctx context.Context, req 
 	}
 
 	if err := task.AddPeerArticketSignature(req.NodeID, req.Signature); err != nil {
-		return nil, errors.Errorf("failed to add peer signature %w", err)
+		return nil, errors.Errorf("add peer signature %w", err)
 	}
 
 	return &pb.SendArtTicketSignatureReply{}, nil

--- a/supernode/node/grpc/server/services/walletnode/download_artwork.go
+++ b/supernode/node/grpc/server/services/walletnode/download_artwork.go
@@ -48,7 +48,7 @@ func (service *DownloadArtwork) Download(m *pb.DownloadRequest, stream pb.Downlo
 			File: data[i*downloadImageBufferSize : (i+1)*downloadImageBufferSize],
 		}
 		if err := stream.Send(res); err != nil {
-			return errors.Errorf("failed to send image data: %w", err)
+			return errors.Errorf("send image data: %w", err)
 		}
 	}
 	if remaining > 0 {
@@ -57,7 +57,7 @@ func (service *DownloadArtwork) Download(m *pb.DownloadRequest, stream pb.Downlo
 			File: data[lastPackageIndex : lastPackageIndex+remaining],
 		}
 		if err := stream.Send(res); err != nil {
-			return errors.Errorf("failed to send image data: %w", err)
+			return errors.Errorf("send image data: %w", err)
 		}
 	}
 

--- a/supernode/node/grpc/server/services/walletnode/process_userdata.go
+++ b/supernode/node/grpc/server/services/walletnode/process_userdata.go
@@ -52,7 +52,7 @@ func (service *ProcessUserdata) Session(stream pbwn.ProcessUserdata_SessionServe
 
 	req, err := stream.Recv()
 	if err != nil {
-		return errors.Errorf("failed to receieve handshake request: %w", err)
+		return errors.Errorf("receieve handshake request: %w", err)
 	}
 	log.WithContext(ctx).WithField("req", req).Debugf("Session request")
 
@@ -64,7 +64,7 @@ func (service *ProcessUserdata) Session(stream pbwn.ProcessUserdata_SessionServe
 		SessID: task.ID(),
 	}
 	if err := stream.Send(resp); err != nil {
-		return errors.Errorf("failed to send handshake response: %w", err)
+		return errors.Errorf("send handshake response: %w", err)
 	}
 	log.WithContext(ctx).WithField("resp", resp).Debugf("Session response")
 
@@ -148,9 +148,7 @@ func (service *ProcessUserdata) SendUserdata(ctx context.Context, req *pbwn.User
 	if err != nil {
 		return nil, err
 	}
-	if req == nil {
-		return nil, errors.Errorf("Request receive from walletnode is nil")
-	}
+
 	// Convert protobuf request to UserdataProcessRequest
 	request := userdata.ProcessRequestSigned{
 		Userdata: &userdata.ProcessRequest{
@@ -223,7 +221,7 @@ func (service *ProcessUserdata) SendUserdata(ctx context.Context, req *pbwn.User
 					if _, err := task.ConnectedToLeader.ProcessUserdata.SendUserdataToLeader(ctx, request); err != nil {
 						processResult.ResponseCode = userdata.ErrorWriteToRQLiteDBFail
 						processResult.Detail = userdata.Description[userdata.ErrorWriteToRQLiteDBFail]
-						actionErr = errors.Errorf("failed to send or write userdata to leader rqlite %w", err)
+						actionErr = errors.Errorf("send or write userdata to leader rqlite %w", err)
 						return nil
 					}
 					// Write success:

--- a/supernode/services/artworkdownload/task.go
+++ b/supernode/services/artworkdownload/task.go
@@ -61,7 +61,7 @@ func (task *Task) DownloadThumbnail(ctx context.Context, key []byte) ([]byte, er
 		base58Key := base58.Encode(key)
 		file, err = task.p2pClient.Retrieve(ctx, base58Key)
 		if err != nil {
-			err = errors.Errorf("failed to fetch p2p key : %s, error: %w", string(base58Key), err)
+			err = errors.Errorf("fetch p2p key : %s, error: %w", string(base58Key), err)
 			task.UpdateStatus(StatusKeyNotFound)
 		}
 		return nil
@@ -163,7 +163,7 @@ func (task *Task) Download(ctx context.Context, txid, timestamp, signature, ttxi
 		// Validate hash of the restored image matches the image hash in the Art Reistration ticket (data_hash)
 		file, err = task.restoreFile(ctx, &nftRegTicket)
 		if err != nil {
-			err = errors.Errorf("failed to restore file: %w", err)
+			err = errors.Errorf("restore file: %w", err)
 		}
 
 		if len(file) == 0 {
@@ -261,7 +261,7 @@ func (task *Task) restoreFile(ctx context.Context, nftRegTicket *pastel.RegTicke
 
 		decodeInfo, err = rqService.Decode(ctx, &encodeInfo)
 		if err != nil {
-			err = errors.Errorf("failed to restore file with rqserivce: %w", err)
+			err = errors.Errorf("restore file with rqserivce: %w", err)
 			task.UpdateStatus(StatusFileDecodingFailed)
 			continue
 		}

--- a/supernode/services/artworkregister/task.go
+++ b/supernode/services/artworkregister/task.go
@@ -141,8 +141,8 @@ func (task *Task) SessionNode(_ context.Context, nodeID string) error {
 		var node *Node
 		node, err = task.pastelNodeByExtKey(ctx, nodeID)
 		if err != nil {
-			log.WithContext(ctx).WithField("nodeID", nodeID).WithError(err).Errorf("failed to get node by extID")
-			err = errors.Errorf("failed to get node by extID %s %w", nodeID, err)
+			log.WithContext(ctx).WithField("nodeID", nodeID).WithError(err).Errorf("get node by extID")
+			err = errors.Errorf("get node by extID %s: %w", nodeID, err)
 			return nil
 		}
 		task.accepted.Add(node)
@@ -169,17 +169,17 @@ func (task *Task) ConnectTo(_ context.Context, nodeID, sessID string) error {
 		var node *Node
 		node, err = task.pastelNodeByExtKey(ctx, nodeID)
 		if err != nil {
-			log.WithContext(ctx).WithField("nodeID", nodeID).WithError(err).Errorf("failed to get node by extID")
+			log.WithContext(ctx).WithField("nodeID", nodeID).WithError(err).Errorf("get node by extID")
 			return nil
 		}
 
 		if err = node.connect(ctx); err != nil {
-			log.WithContext(ctx).WithField("nodeID", nodeID).WithError(err).Errorf("failed to connect to node")
+			log.WithContext(ctx).WithField("nodeID", nodeID).WithError(err).Errorf("connect to node")
 			return nil
 		}
 
 		if err = node.Session(ctx, task.config.PastelID, sessID); err != nil {
-			log.WithContext(ctx).WithField("sessID", sessID).WithField("pastelID", task.config.PastelID).WithError(err).Errorf("failed to handsake with peer")
+			log.WithContext(ctx).WithField("sessID", sessID).WithField("pastelID", task.config.PastelID).WithError(err).Errorf("handsake with peer")
 			return nil
 		}
 
@@ -204,8 +204,8 @@ func (task *Task) ProbeImage(_ context.Context, file *artwork.File) (*pastel.Fin
 		task.ResampledArtwork = file
 		task.fingerAndScores, task.fingerprints, err = task.genFingerprintsData(ctx, task.ResampledArtwork)
 		if err != nil {
-			log.WithContext(ctx).WithError(err).Errorf("failed to generate fingerprints data")
-			err = errors.Errorf("failed to generate fingerprints data %w", err)
+			log.WithContext(ctx).WithError(err).Errorf("generate fingerprints data")
+			err = errors.Errorf("generate fingerprints data: %w", err)
 			return nil
 		}
 		// NOTE: for testing Kademlia and should be removed before releasing.
@@ -244,8 +244,8 @@ func (task *Task) GetRegistrationFee(_ context.Context, ticket []byte, creatorSi
 		// TODO: fix this like how can we get the signature before calling cNode
 		task.Ticket, err = pastel.DecodeNFTTicket(ticket)
 		if err != nil {
-			log.WithContext(ctx).WithError(err).Errorf("failed to decode NFT ticket")
-			err = errors.Errorf("failed to decode NFT ticket %w", err)
+			log.WithContext(ctx).WithError(err).Errorf("decode NFT ticket")
+			err = errors.Errorf("decode NFT ticket %w", err)
 			return nil
 		}
 
@@ -274,8 +274,8 @@ func (task *Task) GetRegistrationFee(_ context.Context, ticket []byte, creatorSi
 
 		task.registrationFee, err = task.pastelClient.GetRegisterNFTFee(ctx, getFeeRequest)
 		if err != nil {
-			log.WithContext(ctx).WithError(err).Errorf("failed to get register NFT fee")
-			err = errors.Errorf("failed to get register NFT fee %w", err)
+			log.WithContext(ctx).WithError(err).Errorf("get register NFT fee")
+			err = errors.Errorf("get register NFT fee %w", err)
 		}
 		return nil
 	})
@@ -296,23 +296,23 @@ func (task *Task) ValidatePreBurnTransaction(ctx context.Context, txid string) (
 
 		// compare rqsymbols
 		if err = task.compareRQSymbolID(ctx); err != nil {
-			log.WithContext(ctx).WithError(err).Errorf("failed to generate rqids")
-			err = errors.Errorf("failed to generate rqids %w", err)
+			log.WithContext(ctx).WithError(err).Errorf("generate rqids")
+			err = errors.Errorf("generate rqids: %w", err)
 			return nil
 		}
 
 		// sign the ticket if not primary node
 		log.WithContext(ctx).Debugf("isPrimary: %t", task.connectedTo == nil)
 		if err = task.signAndSendArtTicket(ctx, task.connectedTo == nil); err != nil {
-			log.WithContext(ctx).WithError(err).Errorf("failed to signed and send NFT ticket")
-			err = errors.Errorf("failed to signed and send NFT ticket")
+			log.WithContext(ctx).WithError(err).Errorf("signed and send NFT ticket")
+			err = errors.Errorf("signed and send NFT ticket")
 			return nil
 		}
 
 		log.WithContext(ctx).Debugf("waiting for confimation")
 		if err = <-confirmationChn; err != nil {
-			log.WithContext(ctx).WithError(err).Errorf("failed to validate preburn transaction validation")
-			err = errors.Errorf("failed to validate preburn transaction validation %w", err)
+			log.WithContext(ctx).WithError(err).Errorf("validate preburn transaction validation")
+			err = errors.Errorf("validate preburn transaction validation :%w", err)
 			return nil
 		}
 		log.WithContext(ctx).Debugf("confirmation done")
@@ -342,38 +342,38 @@ func (task *Task) ValidatePreBurnTransaction(ctx context.Context, txid string) (
 
 					if err = task.verifyPeersSingature(ctx); err != nil {
 						log.WithContext(ctx).WithError(err).Errorf("peers' singature mismatched")
-						err = errors.Errorf("peers' singature mismatched %w", err)
+						err = errors.Errorf("peers' singature mismatched: %w", err)
 						return nil
 					}
 
 					nftRegTxid, err = task.registerArt(ctx)
 					if err != nil {
 						log.WithContext(ctx).WithError(err).Errorf("peers' singature mismatched")
-						err = errors.Errorf("failed to register NFT %w", err)
+						err = errors.Errorf("register NFT: %w", err)
 						return nil
 					}
 
 					// confirmations := task.waitConfirmation(ctx, nftRegTxid, 10, 30*time.Second, 55)
 					// err = <-confirmations
 					// if err != nil {
-					// 	return errors.Errorf("failed to wait for confirmation of reg-art ticket %w", err)
+					// 	return errors.Errorf("wait for confirmation of reg-art ticket %w", err)
 					// }
 
 					if err = task.storeRaptorQSymbols(ctx); err != nil {
-						log.WithContext(ctx).WithError(err).Errorf("failed to store raptor symbols")
-						err = errors.Errorf("failed to store raptor symbols %w", err)
+						log.WithContext(ctx).WithError(err).Errorf("store raptor symbols")
+						err = errors.Errorf("store raptor symbols: %w", err)
 						return nil
 					}
 
 					if err = task.storeThumbnails(ctx); err != nil {
-						log.WithContext(ctx).WithError(err).Errorf("failed to store thumbnails")
-						err = errors.Errorf("failed to store thumbnails %w", err)
+						log.WithContext(ctx).WithError(err).Errorf("store thumbnails")
+						err = errors.Errorf("store thumbnails: %w", err)
 						return nil
 					}
 
 					if err = task.storeFingerprints(ctx); err != nil {
-						log.WithContext(ctx).WithError(err).Errorf("failed to store fingerprints")
-						err = errors.Errorf("failed to store fingerprints %w", err)
+						log.WithContext(ctx).WithError(err).Errorf("store fingerprints")
+						err = errors.Errorf("store fingerprints: %w", err)
 						return nil
 					}
 
@@ -426,16 +426,16 @@ func (task *Task) waitConfirmation(ctx context.Context, txid string, minConfirma
 func (task *Task) signAndSendArtTicket(ctx context.Context, isPrimary bool) error {
 	ticket, err := pastel.EncodeNFTTicket(task.Ticket)
 	if err != nil {
-		return errors.Errorf("failed to serialize NFT ticket %w", err)
+		return errors.Errorf("serialize NFT ticket: %w", err)
 	}
 	task.ownSignature, err = task.pastelClient.Sign(ctx, ticket, task.config.PastelID, task.config.PassPhrase, pastel.SignAlgorithmED448)
 	if err != nil {
-		return errors.Errorf("failed to sign ticket %w", err)
+		return errors.Errorf("sign ticket: %w", err)
 	}
 	if !isPrimary {
 		log.WithContext(ctx).Debug("send signed articket to primary node")
 		if err := task.connectedTo.RegisterArtwork.SendArtTicketSignature(ctx, task.config.PastelID, task.ownSignature); err != nil {
-			return errors.Errorf("failed to send signature to primary node %s at address %s %w", task.connectedTo.ID, task.connectedTo.Address, err)
+			return errors.Errorf("send signature to primary node %s at address %s: %w", task.connectedTo.ID, task.connectedTo.Address, err)
 		}
 	}
 	return nil
@@ -446,11 +446,11 @@ func (task *Task) verifyPeersSingature(ctx context.Context) error {
 
 	data, err := pastel.EncodeNFTTicket(task.Ticket)
 	if err != nil {
-		return errors.Errorf("failed to encoded NFT ticket %w", err)
+		return errors.Errorf("encoded NFT ticket: %w", err)
 	}
 	for nodeID, signature := range task.peersArtTicketSignature {
 		if ok, err := task.pastelClient.Verify(ctx, data, string(signature), nodeID, pastel.SignAlgorithmED448); err != nil {
-			return errors.Errorf("failed to verify signature %s of node %s", signature, nodeID)
+			return errors.Errorf("verify signature %s of node %s", signature, nodeID)
 		} else if !ok {
 			return errors.Errorf("signature of node %s mistmatch", nodeID)
 		}
@@ -496,7 +496,7 @@ func (task *Task) registerArt(ctx context.Context) (string, error) {
 
 	nftRegTxid, err := task.pastelClient.RegisterNFTTicket(ctx, req)
 	if err != nil {
-		return "", errors.Errorf("failed to register NFT work %s", err)
+		return "", errors.Errorf("register NFT work: %w", err)
 	}
 	return nftRegTxid, nil
 }
@@ -504,12 +504,12 @@ func (task *Task) registerArt(ctx context.Context) (string, error) {
 func (task *Task) storeRaptorQSymbols(ctx context.Context) error {
 	img, err := task.Artwork.Bytes()
 	if err != nil {
-		return errors.Errorf("failed to read image data %w", err)
+		return errors.Errorf("read image data: %w", err)
 	}
 
 	conn, err := task.rqClient.Connect(ctx, task.config.RaptorQServiceAddress)
 	if err != nil {
-		return errors.Errorf("failed to connect to raptorq service %w", err)
+		return errors.Errorf("connect to raptorq service: %w", err)
 	}
 
 	rqService := conn.RaptorQ(&rqnode.Config{
@@ -518,18 +518,18 @@ func (task *Task) storeRaptorQSymbols(ctx context.Context) error {
 
 	encodeResp, err := rqService.Encode(ctx, img)
 	if err != nil {
-		return errors.Errorf("failed to create raptorq symbol from image %s %w", task.Artwork.Name(), err)
+		return errors.Errorf("create raptorq symbol from image %s: %w", task.Artwork.Name(), err)
 	}
 
 	for name, data := range task.RQIDS {
 		if _, err := task.p2pClient.Store(ctx, data); err != nil {
-			return errors.Errorf("failed to store raptorq symbols id files %s %w", name, err)
+			return errors.Errorf("store raptorq symbols id files %s: %w", name, err)
 		}
 	}
 
 	for id, symbol := range encodeResp.Symbols {
 		if _, err := task.p2pClient.Store(ctx, symbol); err != nil {
-			return errors.Errorf("failed to store symbolid %s into kamedila %w", id, err)
+			return errors.Errorf("store symbolid %s into kamedila: %w", id, err)
 		}
 	}
 
@@ -540,19 +540,19 @@ func (task *Task) storeThumbnails(ctx context.Context) error {
 	storeFn := func(ctx context.Context, artwork *artwork.File) (string, error) {
 		data, err := artwork.Bytes()
 		if err != nil {
-			return "", errors.Errorf("failed to get data from artwork %s", artwork.Name())
+			return "", errors.Errorf("get data from artwork %s", artwork.Name())
 		}
 		return task.p2pClient.Store(ctx, data)
 	}
 
 	if _, err := storeFn(ctx, task.PreviewThumbnail); err != nil {
-		return errors.Errorf("failed to store preview thumbnail into kamedila %w", err)
+		return errors.Errorf("store preview thumbnail into kamedila: %w", err)
 	}
 	if _, err := storeFn(ctx, task.MediumThumbnail); err != nil {
-		return errors.Errorf("failed to store medium thumbnail into kamedila %w", err)
+		return errors.Errorf("store medium thumbnail into kamedila: %w", err)
 	}
 	if _, err := storeFn(ctx, task.SmallThumbnail); err != nil {
-		return errors.Errorf("failed to store small thumbnail into kamedila %w", err)
+		return errors.Errorf("store small thumbnail into kamedila: %w", err)
 	}
 
 	return nil
@@ -561,11 +561,11 @@ func (task *Task) storeThumbnails(ctx context.Context) error {
 func (task *Task) storeFingerprints(ctx context.Context) error {
 	compressFringerprints, err := zstd.CompressLevel(nil, pastel.Fingerprint(task.fingerprints).Bytes(), 22)
 	if err != nil {
-		return errors.Errorf("failed to compress fingerprint")
+		return errors.Errorf("compress fingerprint")
 	}
 
 	if _, err := task.p2pClient.Store(ctx, compressFringerprints); err != nil {
-		return errors.Errorf("failed to store fingerprints into kamedila")
+		return errors.Errorf("store fingerprints into kamedila")
 	}
 	return nil
 }
@@ -573,13 +573,13 @@ func (task *Task) storeFingerprints(ctx context.Context) error {
 func (task *Task) genFingerprintsData(ctx context.Context, file *artwork.File) (*pastel.FingerAndScores, pastel.Fingerprint, error) {
 	img, err := file.Bytes()
 	if err != nil {
-		return nil, nil, errors.Errorf("failed to get content of image %s %w", file.Name(), err)
+		return nil, nil, errors.Errorf("get content of image %s: %w", file.Name(), err)
 	}
 
 	ddResult, err := task.ddClient.ImageRarenessScore(ctx, img, file.Format().String())
 
 	if err != nil {
-		return nil, nil, errors.Errorf("failed to get dupe detection result from dd-server %w", err)
+		return nil, nil, errors.Errorf("get dupe detection result from dd-server: %w", err)
 	}
 
 	fingerprint := ddResult.Fingerprints
@@ -612,7 +612,7 @@ func (task *Task) genFingerprintsData(ctx context.Context, file *artwork.File) (
 	}
 	compressedFg, err := zstd.CompressLevel(nil, pastel.Fingerprint(fingerprint).Bytes(), 22)
 	if err != nil {
-		return nil, nil, errors.Errorf("failed to compress fingerprint data: %w", err)
+		return nil, nil, errors.Errorf("compress fingerprint data: %w", err)
 	}
 
 	fingerprintAndScores.ZstdCompressedFingerprint = compressedFg
@@ -623,13 +623,13 @@ func (task *Task) compareRQSymbolID(ctx context.Context) error {
 	log.Debugf("Connect to %s", task.config.RaptorQServiceAddress)
 	conn, err := task.rqClient.Connect(ctx, task.config.RaptorQServiceAddress)
 	if err != nil {
-		return errors.Errorf("failed to connect to raptorQ service %w", err)
+		return errors.Errorf("connect to raptorQ service: %w", err)
 	}
 	defer conn.Close()
 
 	content, err := task.Artwork.Bytes()
 	if err != nil {
-		return errors.Errorf("failed to read image contents: %w", err)
+		return errors.Errorf("read image contents: %w", err)
 	}
 
 	rqService := conn.RaptorQ(&rqnode.Config{
@@ -643,7 +643,7 @@ func (task *Task) compareRQSymbolID(ctx context.Context) error {
 	encodeInfo, err := rqService.EncodeInfo(ctx, content, uint32(len(task.RQIDS)), hex.EncodeToString([]byte(task.Ticket.BlockHash)), task.Ticket.AppTicketData.AuthorPastelID)
 
 	if err != nil {
-		return errors.Errorf("failed to generate RaptorQ symbols' identifiers %w", err)
+		return errors.Errorf("generate RaptorQ symbols' identifiers: %w", err)
 	}
 
 	// pick just one file from wallnode to compare rq symbols
@@ -655,7 +655,7 @@ func (task *Task) compareRQSymbolID(ctx context.Context) error {
 	}
 	rawData, err := zstd.Decompress(nil, fromWalletNode)
 	if err != nil {
-		return errors.Errorf("failed to decompress symbols id file: %w", err)
+		return errors.Errorf("decompress symbols id file: %w", err)
 	}
 	scaner := bufio.NewScanner(bytes.NewReader(rawData))
 	scaner.Split(bufio.ScanLines)
@@ -677,7 +677,7 @@ func (task *Task) compareRQSymbolID(ctx context.Context) error {
 	for i := range rawEncodeFile.SymbolIdentifiers {
 		scaner.Scan()
 		if scaner.Err() != nil {
-			return errors.Errorf("failed to scan next symbol identifiers: %w", err)
+			return errors.Errorf("scan next symbol identifiers: %w", err)
 		}
 		symbolFromWalletNode := scaner.Text()
 		if rawEncodeFile.SymbolIdentifiers[i] != symbolFromWalletNode {
@@ -710,15 +710,15 @@ func (task *Task) UploadImageWithThumbnail(_ context.Context, file *artwork.File
 		var fileBytes []byte
 		fileBytes, err = file.Bytes()
 		if err != nil {
-			log.WithContext(ctx).WithError(err).Errorf("failed to read image file")
-			err = errors.Errorf("failed to read image file %w", err)
+			log.WithContext(ctx).WithError(err).Errorf("read image file")
+			err = errors.Errorf("read image file: %w", err)
 			return nil
 		}
 		task.imageSizeBytes = len(fileBytes)
 
 		previewThumbnailHash, mediumThumbnailHash, smallThumbnailHash, err = task.createAndHashThumbnails(coordinate)
 		if err != nil {
-			log.WithContext(ctx).WithError(err).Errorf("failed to create and hash thumbnail")
+			log.WithContext(ctx).WithError(err).Errorf("create and hash thumbnail")
 			return nil
 		}
 
@@ -791,7 +791,7 @@ func (task *Task) removeArtifacts() {
 		if file != nil {
 			log.Debugf("remove file: %s", file.Name())
 			if err := file.Remove(); err != nil {
-				log.Errorf("faile to remove file: %s", err.Error())
+				log.Errorf("failed to remove file: %s", err.Error())
 			}
 		}
 	}

--- a/supernode/services/artworkregister/task_test.go
+++ b/supernode/services/artworkregister/task_test.go
@@ -372,7 +372,7 @@ func TestTaskCompareRQSymbolID(t *testing.T) {
 				fileErr:     nil,
 				assignRQIDS: true,
 			},
-			wantErr: errors.New("failed to decompress"),
+			wantErr: errors.New("decompress"),
 		},
 		"conn-err": {
 			args: args{
@@ -727,7 +727,7 @@ func TestTaskStoreFingerprints(t *testing.T) {
 				},
 				storeErr: errors.New("test"),
 			},
-			wantErr: errors.New("failed to store fingerprints"),
+			wantErr: errors.New("store fingerprints"),
 		},
 	}
 
@@ -1189,7 +1189,7 @@ func TestTaskSessionNode(t *testing.T) {
 				masterNodesErr: errors.New("test"),
 				nodeID:         "A",
 			},
-			wantErr: errors.New("failed to get node"),
+			wantErr: errors.New("get node"),
 		},
 	}
 

--- a/supernode/services/artworkregister/task_thumbnail.go
+++ b/supernode/services/artworkregister/task_thumbnail.go
@@ -83,7 +83,7 @@ func determineSmallQuality(size int) float32 {
 func (task *Task) createAndHashThumbnails(coordinate artwork.ThumbnailCoordinate) (preview []byte, medium []byte, small []byte, err error) {
 	srcImg, err := task.Artwork.LoadImage()
 	if err != nil {
-		err = errors.Errorf("failed to load image from artwork %s %w", task.Artwork.Name(), err)
+		err = errors.Errorf("load image from artwork %s %w", task.Artwork.Name(), err)
 		return
 	}
 
@@ -94,7 +94,7 @@ func (task *Task) createAndHashThumbnails(coordinate artwork.ThumbnailCoordinate
 	previewQuality := determinePreviewQuality(maxInt(originalW, originalH))
 	preview, err = task.createAndHashThumbnail(srcImg, previewThumbnail, nil, previewQuality, fileSizeLimit)
 	if err != nil {
-		err = errors.Errorf("failed to generate thumbnail %w", err)
+		err = errors.Errorf("generate thumbnail %w", err)
 		return
 	}
 
@@ -125,12 +125,12 @@ func (task *Task) createAndHashThumbnails(coordinate artwork.ThumbnailCoordinate
 func (task *Task) createAndHashThumbnail(srcImg image.Image, thumbnail thumbnailType, rect *image.Rectangle, quality float32, targetFileSize int) ([]byte, error) {
 	f := task.Storage.NewFile()
 	if f == nil {
-		return nil, errors.Errorf("failed to create thumbnail file")
+		return nil, errors.Errorf("create thumbnail file failed")
 	}
 
 	previewFile, err := f.Create()
 	if err != nil {
-		return nil, errors.Errorf("failed to create file %s %w", f.Name(), err)
+		return nil, errors.Errorf("create file %s: %w", f.Name(), err)
 	}
 	defer previewFile.Close()
 
@@ -145,18 +145,18 @@ func (task *Task) createAndHashThumbnail(srcImg image.Image, thumbnail thumbnail
 	encoderOptions, err := encoder.NewLossyEncoderOptions(encoder.PresetDefault, quality)
 	encoderOptions.TargetSize = targetFileSize
 	if err != nil {
-		return nil, errors.Errorf("failed to create lossless encoder option %w", err)
+		return nil, errors.Errorf("create lossless encoder option %w", err)
 	}
 
 	if err := webp.Encode(previewFile, thumbnailImg, encoderOptions); err != nil {
-		return nil, errors.Errorf("failed to encode to webp format %w", err)
+		return nil, errors.Errorf("encode to webp format: %w", err)
 	}
 	log.Debugf("preview thumbnail %s", f.Name())
 
 	previewFile.Seek(0, io.SeekStart)
 	hasher := sha3.New256()
 	if _, err := io.Copy(hasher, previewFile); err != nil {
-		return nil, errors.Errorf("hash failed %w", err)
+		return nil, errors.Errorf("hash failed: %w", err)
 	}
 
 	switch thumbnail {

--- a/supernode/services/artworkregister/task_thumbnail_test.go
+++ b/supernode/services/artworkregister/task_thumbnail_test.go
@@ -128,7 +128,7 @@ func newTestImageFile(stg *artwork.Storage) (*artwork.File, error) {
 
 	f, err := imgFile.Create()
 	if err != nil {
-		return nil, errors.Errorf("failed to create storage file: %w", err)
+		return nil, errors.Errorf("create storage file: %w", err)
 	}
 	defer f.Close()
 

--- a/supernode/services/userdataprocess/task.go
+++ b/supernode/services/userdataprocess/task.go
@@ -128,7 +128,7 @@ func (task *Task) SessionNode(_ context.Context, nodeID string) error {
 
 		node, err := task.pastelNodeByExtKey(ctx, nodeID)
 		if err != nil {
-			actionErr = errors.Errorf("failed to get node by extID %s %w", nodeID, err)
+			actionErr = errors.Errorf("get node by extID %s %w", nodeID, err)
 			return nil
 		}
 		task.accepted.Add(node)
@@ -182,7 +182,7 @@ func (task *Task) SupernodeProcessUserdata(ctx context.Context, req *userdata.Pr
 
 	validateResult, err := task.validateUserdata(req.Userdata)
 	if err != nil {
-		return userdata.ProcessResult{}, errors.Errorf("failed to validateUserdata")
+		return userdata.ProcessResult{}, errors.Errorf("validateUserdata")
 	}
 	if validateResult.ResponseCode == userdata.ErrorOnContent {
 		// If the request from Walletnode fail the validation, return the response to Walletnode and stop process further
@@ -223,12 +223,12 @@ func (task *Task) SupernodeProcessUserdata(ctx context.Context, req *userdata.Pr
 	// Marshal validateResult to byte array for signing
 	js, err := json.Marshal(validateResult)
 	if err != nil {
-		return userdata.ProcessResult{}, errors.Errorf("failed to encode validateResult %w", err)
+		return userdata.ProcessResult{}, errors.Errorf("encode validateResult %w", err)
 	}
 	// Hash the validateResult
 	hashvalue, err := userdata.Sha3256hash(js)
 	if err != nil {
-		return userdata.ProcessResult{}, errors.Errorf("failed to hash userdata %w", err)
+		return userdata.ProcessResult{}, errors.Errorf("hash userdata %w", err)
 	}
 	snRequest.UserdataResultHash = hex.EncodeToString(hashvalue)
 	snRequest.UserdataHash = req.UserdataHash
@@ -244,7 +244,7 @@ func (task *Task) SupernodeProcessUserdata(ctx context.Context, req *userdata.Pr
 		}
 		log.WithContext(ctx).Debugf("isPrimary: %t", isPrimary)
 		if err := task.signAndSendSNDataSigned(ctx, task.ownSNData, isPrimary); err != nil {
-			actionErr = errors.Errorf("failed to signed and send SuperNodeRequest:%w", err)
+			actionErr = errors.Errorf("signed and send SuperNodeRequest:%w", err)
 		}
 		return nil
 	})
@@ -301,14 +301,14 @@ func (task *Task) signAndSendSNDataSigned(ctx context.Context, sndata userdata.S
 	log.WithContext(ctx).Debugf("signAndSendSNDataSigned begin to sign SuperNodeRequest")
 	signature, err := task.pastelClient.Sign(ctx, []byte(sndata.UserdataHash+sndata.UserdataResultHash), task.config.PastelID, task.config.PassPhrase, "ed448")
 	if err != nil {
-		return errors.Errorf("failed to sign sndata %w", err)
+		return errors.Errorf("sign sndata %w", err)
 	}
 	if !isPrimary {
 		sndata.HashSignature = hex.EncodeToString(signature)
 		sndata.NodeID = task.config.PastelID
 		log.WithContext(ctx).Debug("send signed sndata to primary node")
 		if _, err := task.ConnectedTo.ProcessUserdata.SendUserdataToPrimary(ctx, sndata); err != nil {
-			return errors.Errorf("failed to send signature to primary node %s at address %s %w", task.ConnectedTo.ID, task.ConnectedTo.Address, err)
+			return errors.Errorf("send signature to primary node %s at address %s %w", task.ConnectedTo.ID, task.ConnectedTo.Address, err)
 		}
 	}
 	return nil

--- a/walletnode/node/grpc/download_artwork.go
+++ b/walletnode/node/grpc/download_artwork.go
@@ -29,7 +29,7 @@ func (service *downloadArtwork) Download(ctx context.Context, txid, timestamp, s
 	var stream pb.DownloadArtwork_DownloadClient
 	stream, err = service.client.Download(ctx, in)
 	if err != nil {
-		err = errors.Errorf("failed to open stream: %w", err)
+		err = errors.Errorf("open stream: %w", err)
 		return
 	}
 	defer stream.CloseSend()

--- a/walletnode/node/grpc/process_userdata.go
+++ b/walletnode/node/grpc/process_userdata.go
@@ -33,7 +33,7 @@ func (service *processUserdata) Session(ctx context.Context, isPrimary bool) err
 
 	stream, err := service.client.Session(ctx)
 	if err != nil {
-		return errors.Errorf("failed to open Health stream: %w", err)
+		return errors.Errorf("open Health stream: %w", err)
 	}
 
 	req := &pb.MDLSessionRequest{
@@ -42,7 +42,7 @@ func (service *processUserdata) Session(ctx context.Context, isPrimary bool) err
 	log.WithContext(ctx).WithField("req", req).Debugf("Session request")
 
 	if err := stream.Send(req); err != nil {
-		return errors.Errorf("failed to send Session request: %w", err)
+		return errors.Errorf("send Session request: %w", err)
 	}
 
 	resp, err := stream.Recv()
@@ -54,7 +54,7 @@ func (service *processUserdata) Session(ctx context.Context, isPrimary bool) err
 		case codes.Canceled, codes.Unavailable:
 			return nil
 		}
-		return errors.Errorf("failed to receive Session response: %w", err)
+		return errors.Errorf("receive Session response: %w", err)
 	}
 	log.WithContext(ctx).WithField("resp", resp).Debugf("Session response")
 	service.sessID = resp.SessID
@@ -81,7 +81,7 @@ func (service *processUserdata) AcceptedNodes(ctx context.Context) (pastelIDs []
 
 	resp, err := service.client.AcceptedNodes(ctx, req)
 	if err != nil {
-		return nil, errors.Errorf("failed to request to accepted secondary nodes: %w", err)
+		return nil, errors.Errorf("request to accepted secondary nodes: %w", err)
 	}
 	log.WithContext(ctx).WithField("resp", resp).Debugf("AcceptedNodes response")
 
@@ -105,7 +105,7 @@ func (service *processUserdata) ConnectTo(ctx context.Context, nodeID, sessID st
 
 	resp, err := service.client.ConnectTo(ctx, req)
 	if err != nil {
-		return errors.Errorf("failed to request to connect to primary node: %w", err)
+		return errors.Errorf("request to connect to primary node: %w", err)
 	}
 	log.WithContext(ctx).WithField("resp", resp).Debugf("ConnectTo response")
 
@@ -152,7 +152,7 @@ func (service *processUserdata) SendUserdata(ctx context.Context, request *userd
 
 	resp, err := service.client.SendUserdata(ctx, reqProto)
 	if err != nil {
-		return nil, errors.Errorf("failed to send data: %w", err)
+		return nil, errors.Errorf("send user data: %w", err)
 	}
 
 	// Convert protobuf response to UserdataProcessResult then return it
@@ -183,7 +183,7 @@ func (service *processUserdata) ReceiveUserdata(ctx context.Context, userpasteli
 	}
 	resp, err := service.client.ReceiveUserdata(ctx, reqProto)
 	if err != nil {
-		return nil, errors.Errorf("failed to receive data: %w", err)
+		return nil, errors.Errorf("receive data: %w", err)
 	}
 
 	var avatarImage userdata.UserImageUpload

--- a/walletnode/node/grpc/register_artwork.go
+++ b/walletnode/node/grpc/register_artwork.go
@@ -41,7 +41,7 @@ func (service *registerArtwork) Session(ctx context.Context, isPrimary bool) err
 
 	stream, err := service.client.Session(ctx)
 	if err != nil {
-		return errors.Errorf("failed to open Health stream: %w", err)
+		return errors.Errorf("open Session stream: %w", err)
 	}
 
 	req := &pb.SessionRequest{
@@ -50,7 +50,7 @@ func (service *registerArtwork) Session(ctx context.Context, isPrimary bool) err
 	log.WithContext(ctx).WithField("req", req).Debugf("Session request")
 
 	if err := stream.Send(req); err != nil {
-		return errors.Errorf("failed to send Session request: %w", err)
+		return errors.Errorf("send Session request: %w", err)
 	}
 
 	resp, err := stream.Recv()
@@ -62,7 +62,7 @@ func (service *registerArtwork) Session(ctx context.Context, isPrimary bool) err
 		case codes.Canceled, codes.Unavailable:
 			return nil
 		}
-		return errors.Errorf("failed to receive Session response: %w", err)
+		return errors.Errorf("receive Session response: %w", err)
 	}
 	log.WithContext(ctx).WithField("resp", resp).Debugf("Session response")
 	service.sessID = resp.SessID
@@ -89,7 +89,7 @@ func (service *registerArtwork) AcceptedNodes(ctx context.Context) (pastelIDs []
 
 	resp, err := service.client.AcceptedNodes(ctx, req)
 	if err != nil {
-		return nil, errors.Errorf("failed to request to accepted secondary nodes: %w", err)
+		return nil, errors.Errorf("request to accepted secondary nodes: %w", err)
 	}
 	log.WithContext(ctx).WithField("resp", resp).Debugf("AcceptedNodes response")
 
@@ -113,7 +113,7 @@ func (service *registerArtwork) ConnectTo(ctx context.Context, nodeID, sessID st
 
 	resp, err := service.client.ConnectTo(ctx, req)
 	if err != nil {
-		return errors.Errorf("failed to request to connect to primary node: %w", err)
+		return err
 	}
 	log.WithContext(ctx).WithField("resp", resp).Debugf("ConnectTo response")
 
@@ -127,13 +127,13 @@ func (service *registerArtwork) ProbeImage(ctx context.Context, image *artwork.F
 
 	stream, err := service.client.ProbeImage(ctx)
 	if err != nil {
-		return nil, errors.Errorf("failed to open stream: %w", err)
+		return nil, errors.Errorf("open stream: %w", err)
 	}
 	defer stream.CloseSend()
 
 	file, err := image.Open()
 	if err != nil {
-		return nil, errors.Errorf("failed to open file %q: %w", file.Name(), err)
+		return nil, errors.Errorf("open file %q: %w", file.Name(), err)
 	}
 	defer file.Close()
 
@@ -148,13 +148,13 @@ func (service *registerArtwork) ProbeImage(ctx context.Context, image *artwork.F
 			Payload: buffer[:n],
 		}
 		if err := stream.Send(req); err != nil {
-			return nil, errors.Errorf("failed to send image data: %w", err).WithField("reqID", service.conn.id)
+			return nil, errors.Errorf("send image data: %w", err)
 		}
 	}
 
 	resp, err := stream.CloseAndRecv()
 	if err != nil {
-		return nil, errors.Errorf("failed to receive send image response: %w", err)
+		return nil, errors.Errorf("receive image response: %w", err)
 	}
 	return &pastel.FingerAndScores{
 		DupeDectectionSystemVersion: resp.DupeDetectionVersion,
@@ -191,13 +191,13 @@ func (service *registerArtwork) UploadImageWithThumbnail(ctx context.Context, im
 	log.WithContext(ctx).Debug("Start upload image and thumbnail to node")
 	stream, err := service.client.UploadImage(ctx)
 	if err != nil {
-		return nil, nil, nil, errors.Errorf("failed to open stream: %w", err)
+		return nil, nil, nil, errors.Errorf("open stream: %w", err)
 	}
 	defer stream.CloseSend()
 
 	file, err := image.Open()
 	if err != nil {
-		return nil, nil, nil, errors.Errorf("failed to open file %q: %w", file.Name(), err)
+		return nil, nil, nil, errors.Errorf("open file %q: %w", file.Name(), err)
 	}
 	defer file.Close()
 
@@ -212,7 +212,7 @@ func (service *registerArtwork) UploadImageWithThumbnail(ctx context.Context, im
 			lastPiece = true
 			break
 		} else if err != nil {
-			return nil, nil, nil, errors.Errorf("read file faile %w", err)
+			return nil, nil, nil, errors.Errorf("read file: %w", err)
 		}
 
 		req := &pb.UploadImageRequest{
@@ -222,19 +222,19 @@ func (service *registerArtwork) UploadImageWithThumbnail(ctx context.Context, im
 		}
 
 		if err := stream.Send(req); err != nil {
-			return nil, nil, nil, errors.Errorf("failed to send image data: %w", err).WithField("ReqID", service.conn.id)
+			return nil, nil, nil, errors.Errorf("send image data: %w", err)
 		}
 	}
 
 	log.WithContext(ctx).Debugf("Encoded Image Size :%d\n", payloadSize)
 	if !lastPiece {
-		return nil, nil, nil, errors.Errorf("failed to read all image data")
+		return nil, nil, nil, errors.Errorf("read all image data failed")
 	}
 
 	file.Seek(0, io.SeekStart)
 	hasher := sha3.New256()
 	if _, err := io.Copy(hasher, file); err != nil {
-		return nil, nil, nil, errors.Errorf("failed to compute artwork hash %w", err)
+		return nil, nil, nil, errors.Errorf("compute artwork hash:%w", err)
 	}
 	hash := hasher.Sum(nil)
 	log.WithContext(ctx).WithField("Filename", file.Name()).Debugf("hash: %s", base64.URLEncoding.EncodeToString(hash))
@@ -256,12 +256,12 @@ func (service *registerArtwork) UploadImageWithThumbnail(ctx context.Context, im
 	}
 
 	if err := stream.Send(thumnailReq); err != nil {
-		return nil, nil, nil, errors.Errorf("failed to send image thumbnail: %w", err).WithField("ReqID", service.conn.id)
+		return nil, nil, nil, errors.Errorf("send image thumbnail: %w", err)
 	}
 
 	resp, err := stream.CloseAndRecv()
 	if err != nil {
-		return nil, nil, nil, errors.Errorf("failed to receive upload image response: %w", err)
+		return nil, nil, nil, errors.Errorf("receive upload image response: %w", err)
 	}
 	log.WithContext(ctx).Debugf("preview medium hash: %x", resp.PreviewThumbnailHash)
 	log.WithContext(ctx).Debugf("medium thumbnail hash: %x", resp.MediumThumbnailHash)
@@ -297,7 +297,7 @@ func (service *registerArtwork) SendSignedTicket(ctx context.Context, ticket []b
 
 	rsp, err := service.client.SendSignedNFTTicket(ctx, &req)
 	if err != nil {
-		return -1, errors.Errorf("failed to send signed ticket and its signature to node %w", err)
+		return -1, err
 	}
 
 	return rsp.RegistrationFee, nil
@@ -314,7 +314,7 @@ func (service *registerArtwork) SendPreBurntFeeTxid(ctx context.Context, txid st
 
 	rsp, err := service.client.SendPreBurntFeeTxid(ctx, &req)
 	if err != nil {
-		return "", errors.Errorf("failed to send burned txid to super node %w", err)
+		return "", errors.Errorf("send burned txid to super node: %w", err)
 	}
 
 	// TODO: response from sending preburned TxId should be the TxId of RegActTicket

--- a/walletnode/services/artworkdownload/task.go
+++ b/walletnode/services/artworkdownload/task.go
@@ -57,7 +57,7 @@ func (task *Task) run(ctx context.Context) error {
 	ttxid, err := task.pastelClient.TicketOwnership(ctx, task.Ticket.Txid, task.Ticket.PastelID, task.Ticket.PastelIDPassphrase)
 	if err != nil {
 		log.WithContext(ctx).WithError(err).WithField("txid", task.Ticket.Txid).WithField("pastelid", task.Ticket.PastelID).Error("Could not get ticket ownership")
-		return errors.Errorf("failed to get ticket ownership: %w", err)
+		return errors.Errorf("get ticket ownership: %w", err)
 	}
 
 	// Sign current-timestamp with PsstelID passed in request
@@ -65,13 +65,13 @@ func (task *Task) run(ctx context.Context) error {
 	signature, err := task.pastelClient.Sign(ctx, []byte(timestamp), task.Ticket.PastelID, task.Ticket.PastelIDPassphrase, "ed448")
 	if err != nil {
 		log.WithContext(ctx).WithError(err).WithField("timestamp", timestamp).WithField("pastelid", task.Ticket.PastelID).Error("Could not sign timestamp")
-		return errors.Errorf("failed to sign timestamp: %w", err)
+		return errors.Errorf("sign timestamp: %w", err)
 	}
 
 	// Retrieve supernodes with highest ranks.
 	topNodes, err := task.pastelTopNodes(ctx)
 	if err != nil {
-		return errors.Errorf("failed to get top rank nodes: %w", err)
+		return errors.Errorf("get top rank nodes: %w", err)
 	}
 	if len(topNodes) < task.config.NumberSuperNodes {
 		task.UpdateStatus(StatusErrorNotEnoughSuperNode)
@@ -109,7 +109,7 @@ func (task *Task) run(ctx context.Context) error {
 	if err != nil {
 		log.WithContext(ctx).WithError(err).WithField("txid", task.Ticket.Txid).Error("Could not download files")
 		task.UpdateStatus(StatusErrorDownloadFailed)
-		return errors.Errorf("failed to download files from supernodes: %w", err)
+		return errors.Errorf("download files from supernodes: %w", err)
 	}
 
 	nodes = connectedNodes.Active()

--- a/walletnode/services/artworkregister/node/list_test.go
+++ b/walletnode/services/artworkregister/node/list_test.go
@@ -3,10 +3,10 @@ package node
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 
-	"github.com/pastelnetwork/gonode/common/errors"
 	"github.com/pastelnetwork/gonode/common/service/artwork"
 	"github.com/pastelnetwork/gonode/pastel"
 	"github.com/pastelnetwork/gonode/walletnode/node/test"
@@ -238,7 +238,7 @@ func TestNodesSendImage(t *testing.T) {
 
 			err := nodes.ProbeImage(testCase.args.ctx, testCase.args.file)
 			if err != nil {
-				assert.Equal(t, errors.Errorf("failed to probe image: %w", testCase.err).Error(), err.Error())
+				assert.True(t, strings.Contains(err.Error(), testCase.err.Error()))
 			} else {
 				assert.Equal(t, err, testCase.err)
 			}

--- a/walletnode/services/artworkregister/service.go
+++ b/walletnode/services/artworkregister/service.go
@@ -44,7 +44,7 @@ func (service *Service) Run(ctx context.Context) error {
 			ImagePath *string `json:"image_path"`
 		}{}
 		if err := json.Unmarshal([]byte(test), &ticket); err != nil {
-			return errors.Errorf("failed to marshal ticket %q : %w", test, err)
+			return errors.Errorf("marshal ticket %q : %w", test, err)
 		}
 
 		if imagePath := ticket.ImagePath; imagePath != nil {

--- a/walletnode/services/artworkregister/task.go
+++ b/walletnode/services/artworkregister/task.go
@@ -353,10 +353,10 @@ func (task *Task) meshNodes(ctx context.Context, nodes node.List, primaryIndex i
 				go func() {
 					defer errors.Recover(log.Fatal)
 
-					if err := node.Connect(nextConnCtx, task.config.ConnectToNodeTimeout, secInfo); err != nil {
+					if err := node.Connect(ctx, task.config.ConnectToNodeTimeout, secInfo); err != nil {
 						return
 					}
-					if err := node.Session(nextConnCtx, false); err != nil {
+					if err := node.Session(ctx, false); err != nil {
 						return
 					}
 					// Should not run this code in go routine
@@ -366,7 +366,7 @@ func (task *Task) meshNodes(ctx context.Context, nodes node.List, primaryIndex i
 						secondaries.Add(node)
 					}()
 
-					if err := node.ConnectTo(nextConnCtx, primary.PastelID(), primary.SessID()); err != nil {
+					if err := node.ConnectTo(ctx, primary.PastelID(), primary.SessID()); err != nil {
 						return
 					}
 					log.WithContext(ctx).Debugf("Seconary %q connected to primary", node)

--- a/walletnode/services/artworkregister/task.go
+++ b/walletnode/services/artworkregister/task.go
@@ -79,7 +79,7 @@ func (task *Task) Run(ctx context.Context) error {
 	defer task.removeArtifacts()
 	if err := task.run(ctx); err != nil {
 		task.UpdateStatus(StatusTaskRejected)
-		log.WithContext(ctx).WithErrorStack(err).Warnf("Task is rejected")
+		log.WithContext(ctx).WithErrorStack(err).Error("Task is rejected")
 		return nil
 	}
 
@@ -100,7 +100,7 @@ func (task *Task) run(ctx context.Context) error {
 
 	// Retrieve supernodes with highest ranks.
 	if err := task.connectToTopRankNodes(ctx); err != nil {
-		return errors.Errorf("failed to connect to top rank nodes: %w", err)
+		return errors.Errorf("connect to top rank nodes: %w", err)
 	}
 
 	// supervise the connection to top rank nodes
@@ -114,74 +114,77 @@ func (task *Task) run(ctx context.Context) error {
 
 	// get block height + hash
 	if err := task.getBlock(ctx); err != nil {
-		return errors.Errorf("failed to get current block heigth %w", err)
+		return errors.Errorf("get current block heigth: %w", err)
 	}
 
 	// probe image for rareness, nsfw and seen score
 	if err := task.probeImage(ctx); err != nil {
-		return errors.Errorf("failed to probe image: %w", err)
+		return errors.Errorf("probe image: %w", err)
 	}
 
 	// upload image and thumbnail coordinates to supernode(s)
 	if err := task.uploadImage(ctx); err != nil {
-		return errors.Errorf("failed to upload image: %w", err)
+		return errors.Errorf("upload image: %w", err)
 	}
 
 	// connect to rq serivce to get rq symbols identifier
 	if err := task.genRQIdentifiersFiles(ctx); err != nil {
-		return errors.Errorf("gen RaptorQ symbols' identifiers failed %w", err)
+		return errors.Errorf("gen RaptorQ symbols' identifiers: %w", err)
 	}
 
 	if err := task.createArtTicket(ctx); err != nil {
-		return errors.Errorf("failed to create ticket %w", err)
+		return errors.Errorf("create ticket: %w", err)
 	}
 
 	// sign ticket with artist signature
 	if err := task.signTicket(ctx); err != nil {
-		return errors.Errorf("failed to sign NFT ticket %w", err)
+		return errors.Errorf("sign NFT ticket: %w", err)
 	}
 
 	// send signed ticket to supernodes to calculate registration fee
 	if err := task.sendSignedTicket(ctx); err != nil {
-		return errors.Errorf("failed to send signed NFT ticket: %w", err)
+		return errors.Errorf("send signed NFT ticket: %w", err)
 	}
 
 	// validate if address has enough psl
 	if err := task.checkCurrentBalance(ctx, float64(task.registrationFee)); err != nil {
-		return errors.Errorf("failed to check current balance: %w", err)
+		return errors.Errorf("check current balance: %w", err)
 	}
 
 	// send preburn-txid to master node(s)
 	// master node will create reg-art ticket and returns transaction id
 	if err := task.preburntRegistrationFee(ctx); err != nil {
-		return errors.Errorf("faild to pre-burnt ten percent of registration fee: %w", err)
+		return errors.Errorf("pre-burnt ten percent of registration fee: %w", err)
 	}
 
-	log.WithContext(ctx).Debugf("close connection")
+	log.WithContext(ctx).Debugf("close connections to supernodes")
 	close(nodesDone)
 	for i := range task.nodes {
 		if err := task.nodes[i].Connection.Close(); err != nil {
-			log.WithContext(ctx).WithError(err).Debugf("failed to close connection to node %s", task.nodes[i].PastelID())
+			log.WithContext(ctx).WithFields(log.Fields{
+				"pastelId": task.nodes[i].PastelID(),
+				"addr":     task.nodes[i].String(),
+			}).WithError(err).Errorf("close supernode connection failed")
 		}
 	}
 
 	// new context because the old context already cancelled
 	newCtx := context.Background()
 	if err := task.waitTxidValid(newCtx, task.regNFTTxid, int64(task.config.RegArtTxMinConfirmations), task.config.RegArtTxTimeout, 15*time.Second); err != nil {
-		return errors.Errorf("failed to wait reg-nft ticket valid %w", err)
+		return errors.Errorf("wait reg-nft ticket valid: %w", err)
 	}
 
 	// activate reg-art ticket at previous step
 	actTxid, err := task.registerActTicket(newCtx)
 	if err != nil {
-		return errors.Errorf("failed to register act ticket %w", err)
+		return errors.Errorf("register act ticket: %w", err)
 	}
 	log.Debugf("reg-act-txid: %s", actTxid)
 
 	// Wait until actTxid is valid
 	err = task.waitTxidValid(newCtx, actTxid, int64(task.config.RegActTxMinConfirmations), task.config.RegActTxTimeout, 15*time.Second)
 	if err != nil {
-		return errors.Errorf("failed to reg-act ticket valid %w", err)
+		return errors.Errorf("reg-act ticket valid: %w", err)
 	}
 	log.Debugf("reg-act-tixd is confirmed")
 
@@ -190,7 +193,7 @@ func (task *Task) run(ctx context.Context) error {
 
 func (task *Task) checkCurrentBalance(ctx context.Context, registrationFee float64) error {
 	if registrationFee == 0 {
-		return errors.Errorf("registration fee cannot be 0.0")
+		return errors.Errorf("invalid registration fee: %f", registrationFee)
 	}
 
 	if registrationFee > task.Request.MaximumFee {
@@ -199,7 +202,7 @@ func (task *Task) checkCurrentBalance(ctx context.Context, registrationFee float
 
 	balance, err := task.pastelClient.GetBalance(ctx, task.Request.SpendableAddress)
 	if err != nil {
-		return errors.Errorf("failed to get current balance of address(%s): %w", task.Request.SpendableAddress, err)
+		return errors.Errorf("get balance of address(%s): %w", task.Request.SpendableAddress, err)
 	}
 
 	if balance < registrationFee {
@@ -223,7 +226,7 @@ func (task *Task) waitTxidValid(ctx context.Context, txID string, expectedConfir
 	for {
 		select {
 		case <-ctx.Done():
-			return errors.Errorf("context done %w", ctx.Err())
+			return errors.Errorf("context done: %w", ctx.Err())
 		case <-time.After(interval):
 			checkConfirms := func() error {
 				subCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
@@ -232,14 +235,14 @@ func (task *Task) waitTxidValid(ctx context.Context, txID string, expectedConfir
 				result, err := task.pastelClient.GetRawTransactionVerbose1(subCtx, txID)
 				log.WithContext(ctx).Debugf("getrawtransaction result: %s %v", txID, result)
 				if err != nil {
-					return errors.Errorf("failed to get transaction %w", err)
+					return errors.Errorf("get transaction: %w", err)
 				}
 
 				if result.Confirmations >= expectedConfirms {
 					return nil
 				}
 
-				return errors.Errorf("confirmations not meet: expected %d, got %d", expectedConfirms, result.Confirmations)
+				return errors.Errorf("not enough confirmations: expected %d, got %d", expectedConfirms, result.Confirmations)
 			}
 
 			err := checkConfirms()
@@ -259,17 +262,17 @@ func (task *Task) encodeFingerprint(ctx context.Context, fingerprint []byte, img
 	ed448PubKey := []byte(task.Request.ArtistPastelID)
 	ed448Signature, err := task.pastelClient.Sign(ctx, fingerprint, task.Request.ArtistPastelID, task.Request.ArtistPastelIDPassphrase, pastel.SignAlgorithmED448)
 	if err != nil {
-		return errors.Errorf("sign fingerprint with pastelId and pastelPassphrase failed %w", err)
+		return errors.Errorf("sign fingerprint: %w", err)
 	}
 
 	// TODO: Should be replaced with real data from the Pastel API.
 	ticket, err := task.pastelClient.FindTicketByID(ctx, task.Request.ArtistPastelID)
 	if err != nil {
-		return errors.Errorf("failed to find register ticket of artist pastel id:%s :%w", task.Request.ArtistPastelID, err)
+		return errors.Errorf("find register ticket of artist pastel id(%s):%w", task.Request.ArtistPastelID, err)
 	}
 	pqSignature, err := task.pastelClient.Sign(ctx, fingerprint, task.Request.ArtistPastelID, task.Request.ArtistPastelIDPassphrase, pastel.SignAlgorithmLegRoast)
 	if err != nil {
-		return errors.Errorf("failed to sign fingerprint with legroats: %w", err)
+		return errors.Errorf("sign fingerprint with legroats: %w", err)
 	}
 
 	// Encode data to the image.
@@ -321,6 +324,7 @@ func (task *Task) meshNodes(ctx context.Context, nodes node.List, primaryIndex i
 	}
 
 	primary := nodes[primaryIndex]
+	log.WithContext(ctx).Debugf("Trying to connect to primary node %q", primary)
 	if err := primary.Connect(ctx, task.config.ConnectToNodeTimeout, secInfo); err != nil {
 		return nil, err
 	}
@@ -349,19 +353,20 @@ func (task *Task) meshNodes(ctx context.Context, nodes node.List, primaryIndex i
 				go func() {
 					defer errors.Recover(log.Fatal)
 
-					if err := node.Connect(ctx, task.config.ConnectToNodeTimeout, secInfo); err != nil {
+					if err := node.Connect(nextConnCtx, task.config.ConnectToNodeTimeout, secInfo); err != nil {
 						return
 					}
-					if err := node.Session(ctx, false); err != nil {
+					if err := node.Session(nextConnCtx, false); err != nil {
 						return
 					}
-					go func() {
+					// Should not run this code in go routine
+					func() {
 						secondariesMtx.Lock()
 						defer secondariesMtx.Unlock()
 						secondaries.Add(node)
 					}()
 
-					if err := node.ConnectTo(ctx, primary.PastelID(), primary.SessID()); err != nil {
+					if err := node.ConnectTo(nextConnCtx, primary.PastelID(), primary.SessID()); err != nil {
 						return
 					}
 					log.WithContext(ctx).Debugf("Seconary %q connected to primary", node)
@@ -426,19 +431,19 @@ func (task *Task) getBlock(ctx context.Context) error {
 	blockNum, err := task.pastelClient.GetBlockCount(ctx)
 	task.creatorBlockHeight = int(blockNum)
 	if err != nil {
-		return errors.Errorf("failed to get block num: %w", err)
+		return errors.Errorf("get block num: %w", err)
 	}
 
 	// Get block hash string
 	blockInfo, err := task.pastelClient.GetBlockVerbose1(ctx, blockNum)
 	if err != nil {
-		return errors.Errorf("failed to get block info with given block num %d: %w", blockNum, err)
+		return errors.Errorf("get block info blocknum=%d: %w", blockNum, err)
 	}
 
 	// Decode hash string to byte
 	task.creatorBlockHash = blockInfo.Hash
 	if err != nil {
-		return errors.Errorf("failed to convert hash string %s to bytes: %w", blockInfo.Hash, err)
+		return errors.Errorf("convert hash string %s to bytes: %w", blockInfo.Hash, err)
 	}
 
 	return nil
@@ -448,13 +453,13 @@ func (task *Task) genRQIdentifiersFiles(ctx context.Context) error {
 	log.Debugf("Connect to %s", task.config.RaptorQServiceAddress)
 	conn, err := task.rqClient.Connect(ctx, task.config.RaptorQServiceAddress)
 	if err != nil {
-		return errors.Errorf("failed to connect to raptorQ service %w", err)
+		return errors.Errorf("connect to raptorQ: %w", err)
 	}
 	defer conn.Close()
 
 	content, err := task.imageEncodedWithFingerprints.Bytes()
 	if err != nil {
-		return errors.Errorf("failed to read image contents: %w", err)
+		return errors.Errorf("read image content: %w", err)
 	}
 
 	rqService := conn.RaptorQ(&rqnode.Config{
@@ -466,7 +471,7 @@ func (task *Task) genRQIdentifiersFiles(ctx context.Context) error {
 	// - check format of artis block hash should be base58 or not
 	encodeInfo, err := rqService.EncodeInfo(ctx, content, task.config.NumberRQIDSFiles, task.creatorBlockHash, task.Request.ArtistPastelID)
 	if err != nil {
-		return errors.Errorf("failed to generate RaptorQ symbols' identifiers %w", err)
+		return errors.Errorf("generate RaptorQ symbols identifiers: %w", err)
 	}
 
 	files := make(map[string][]byte)
@@ -474,13 +479,13 @@ func (task *Task) genRQIdentifiersFiles(ctx context.Context) error {
 		name, content, err := task.convertToSymbolIDFile(ctx, rawSymbolIDFile)
 		if err != nil {
 			task.UpdateStatus(StatusErrorGenRaptorQSymbolsFailed)
-			return errors.Errorf("failed to create rqids file %w", err)
+			return errors.Errorf("create rqids file :%w", err)
 		}
 		files[name] = content
 	}
 
 	if len(files) < 1 {
-		return errors.Errorf("nuber of raptorq symbol identifiers files must be greater than 1")
+		return errors.Errorf("number of raptorq symbol identifiers files must be greater than 1")
 	}
 	for k := range files {
 		log.WithContext(ctx).Debugf("symbol file identifier %s", k)
@@ -510,7 +515,7 @@ func (task *Task) convertToSymbolIDFile(ctx context.Context, rawFile rqnode.RawS
 	// log.WithContext(ctx).Debugf("%s", content)
 	signature, err := task.pastelClient.Sign(ctx, content, task.Request.ArtistPastelID, task.Request.ArtistPastelIDPassphrase, pastel.SignAlgorithmED448)
 	if err != nil {
-		return "", nil, errors.Errorf("failed to sign identifiers file: %w", err)
+		return "", nil, errors.Errorf("sign identifiers file: %w", err)
 	}
 	content = append(content, signature...)
 
@@ -518,12 +523,12 @@ func (task *Task) convertToSymbolIDFile(ctx context.Context, rawFile rqnode.RawS
 	// compress the contente of the file
 	compressedData, err := zstd.CompressLevel(nil, content, 22)
 	if err != nil {
-		return "", nil, errors.Errorf("failed to compress: ")
+		return "", nil, errors.Errorf("compress identifiers file: %w", err)
 	}
 	hasher := sha3.New256()
 	src := bytes.NewReader(compressedData)
 	if _, err := io.Copy(hasher, src); err != nil {
-		return "", nil, errors.Errorf("failed to hash identifiers file %w", err)
+		return "", nil, errors.Errorf("hash identifiers file: %w", err)
 	}
 	return base58.Encode(hasher.Sum(nil)), compressedData, nil
 }
@@ -619,12 +624,12 @@ func (task *Task) createArtTicket(_ context.Context) error {
 func (task *Task) signTicket(ctx context.Context) error {
 	data, err := pastel.EncodeNFTTicket(task.ticket)
 	if err != nil {
-		return errors.Errorf("failed to encode ticket %w", err)
+		return errors.Errorf("encode ticket %w", err)
 	}
 
 	task.creatorSignature, err = task.pastelClient.Sign(ctx, data, task.Request.ArtistPastelID, task.Request.ArtistPastelIDPassphrase, pastel.SignAlgorithmED448)
 	if err != nil {
-		return errors.Errorf("failed to sign ticket %w", err)
+		return errors.Errorf("sign ticket %w", err)
 	}
 	return nil
 }
@@ -646,7 +651,7 @@ func (task *Task) connectToTopRankNodes(ctx context.Context) error {
 	// Retrieve supernodes with highest ranks.
 	topNodes, err := task.pastelTopNodes(ctx)
 	if err != nil {
-		return errors.Errorf("failed to call masternode top: %w", err)
+		return errors.Errorf("call masternode top: %w", err)
 	}
 
 	if len(topNodes) < task.config.NumberSuperNodes {
@@ -671,9 +676,13 @@ func (task *Task) connectToTopRankNodes(ctx context.Context) error {
 	// Try to create mesh of supernodes, connecting to all supernodes in a different sequences.
 	var nodes node.List
 	var errs error
+
 	for primaryRank := range topNodes {
 		nodes, err = task.meshNodes(ctx, topNodes, primaryRank)
 		if err != nil {
+			// close connected connections
+			topNodes.DisconnectAll()
+
 			if errors.IsContextCanceled(err) {
 				return err
 			}
@@ -684,6 +693,8 @@ func (task *Task) connectToTopRankNodes(ctx context.Context) error {
 		break
 	}
 	if len(nodes) < task.config.NumberSuperNodes {
+		// close connected connections
+		topNodes.DisconnectAll()
 		return errors.Errorf("Could not create a mesh of %d nodes: %w", task.config.NumberSuperNodes, errs)
 	}
 
@@ -702,9 +713,9 @@ func (task *Task) connectToTopRankNodes(ctx context.Context) error {
 func (task *Task) probeImage(ctx context.Context) error {
 	log.WithContext(ctx).WithField("filename", task.Request.Image.Name()).Debugf("probe image")
 
-	// Send thumbnail to supernodes for probing.
+	// Send image to supernodes for probing.
 	if err := task.nodes.ProbeImage(ctx, task.Request.Image); err != nil {
-		return errors.Errorf("failed to probe image: %w", err)
+		return errors.Errorf("send image: %w", err)
 	}
 
 	// Match fingerprints received from supernodes.
@@ -719,14 +730,14 @@ func (task *Task) probeImage(ctx context.Context) error {
 	// so we calculated the hash base on the compressed fingerprint print also
 	fingerprintsHash, err := sha3256hash(task.fingerprintAndScores.ZstdCompressedFingerprint)
 	if err != nil {
-		return errors.Errorf("failed to hash zstd commpressed fingerprints %w", err)
+		return errors.Errorf("hash zstd commpressed fingerprints: %w", err)
 	}
 	task.fingerprintsHash = []byte(base58.Encode(fingerprintsHash))
 
 	// Decompress the fingerprint as bytes for later use
 	task.fingerprint, err = zstd.Decompress(nil, task.fingerprintAndScores.ZstdCompressedFingerprint)
 	if err != nil {
-		return errors.Errorf("failed to decompress finger")
+		return errors.Errorf("decompress finger failed")
 	}
 	return nil
 }
@@ -734,32 +745,32 @@ func (task *Task) probeImage(ctx context.Context) error {
 func (task *Task) uploadImage(ctx context.Context) error {
 	img1, err := task.Request.Image.Copy()
 	if err != nil {
-		return errors.Errorf("copy image to encode failed %w", err)
+		return errors.Errorf("copy image to encode: %w", err)
 	}
 
 	log.WithContext(ctx).WithField("FileName", img1.Name()).Debugf("final image")
 	if err := task.encodeFingerprint(ctx, task.fingerprint, img1); err != nil {
-		return errors.Errorf("encode image with fingerprint %w", err)
+		return errors.Errorf("encode image with fingerprint: %w", err)
 	}
 	task.imageEncodedWithFingerprints = img1
 
 	imgBytes, err := img1.Bytes()
 	if err != nil {
-		return errors.Errorf("failed to convert image to byte stream %w", err)
+		return errors.Errorf("convert image to byte stream %w", err)
 	}
 
 	if task.datahash, err = sha3256hash(imgBytes); err != nil {
-		return errors.Errorf("failed to hash encoded image: %w", err)
+		return errors.Errorf("hash encoded image: %w", err)
 	}
 
 	// Upload image with pqgsinganature and its thumb to supernodes
 	if err := task.nodes.UploadImageWithThumbnail(ctx, img1, task.Request.Thumbnail); err != nil {
-		return errors.Errorf("upload encoded image and thumbnail coordinate failed %w", err)
+		return errors.Errorf("upload encoded image and thumbnail coordinate: %w", err)
 	}
 	// Match thumbnail hashes receiveed from supernodes
 	if err := task.nodes.MatchThumbnailHashes(); err != nil {
 		task.UpdateStatus(StatusErrorThumbnailHashsesNotMatch)
-		return errors.Errorf("thumbnail hash returns by supenodes not mached %w", err)
+		return errors.Errorf("thumbnail hash returns by supenodes not mached: %w", err)
 	}
 	task.UpdateStatus(StatusImageAndThumbnailUploaded)
 
@@ -773,16 +784,16 @@ func (task *Task) uploadImage(ctx context.Context) error {
 func (task *Task) sendSignedTicket(ctx context.Context) error {
 	buf, err := pastel.EncodeNFTTicket(task.ticket)
 	if err != nil {
-		return errors.Errorf("failed to marshal ticket %w", err)
+		return errors.Errorf("marshal ticket: %w", err)
 	}
 	log.Debug(string(buf))
 
 	if err := task.nodes.UploadSignedTicket(ctx, buf, task.creatorSignature, task.rqSymbolIDFiles, task.rqEncodeParams); err != nil {
-		return errors.Errorf("failed to upload signed ticket %w", err)
+		return errors.Errorf("upload signed ticket: %w", err)
 	}
 
 	if err := task.nodes.MatchRegistrationFee(); err != nil {
-		return errors.Errorf("registration fees don't matched %w", err)
+		return errors.Errorf("registration fees don't matched: %w", err)
 	}
 
 	// check if fee is over-expection
@@ -804,17 +815,17 @@ func (task *Task) preburntRegistrationFee(ctx context.Context) error {
 	burnedAmount := float64(task.registrationFee) / 10
 	burnTxid, err := task.pastelClient.SendFromAddress(ctx, task.Request.SpendableAddress, task.config.BurnAddress, burnedAmount)
 	if err != nil {
-		return errors.Errorf("failed to burn 10 percent of transaction fee %w", err)
+		return errors.Errorf("burn 10 percent of transaction fee: %w", err)
 	}
 	task.burnTxid = burnTxid
 	log.WithContext(ctx).Debugf("preburn txid: %s", task.burnTxid)
 
 	if err := task.nodes.SendPreBurntFeeTxid(ctx, task.burnTxid); err != nil {
-		return errors.Errorf("failed to send pre-burn-txid: %s to supernode(s): %w", task.burnTxid, err)
+		return errors.Errorf("send pre-burn-txid: %s to supernode(s): %w", task.burnTxid, err)
 	}
 	task.regNFTTxid = task.nodes.RegArtTicketID()
 	if task.regNFTTxid == "" {
-		return errors.Errorf("regNFTTxid is empty")
+		return errors.Errorf("empty regNFTTxid")
 	}
 
 	return nil
@@ -825,7 +836,7 @@ func (task *Task) removeArtifacts() {
 		if file != nil {
 			log.Debugf("remove file: %s", file.Name())
 			if err := file.Remove(); err != nil {
-				log.Debugf("failed to remove filed: %s", err.Error())
+				log.Debugf("remove file failed: %s", err.Error())
 			}
 		}
 	}

--- a/walletnode/services/artworkregister/task_test.go
+++ b/walletnode/services/artworkregister/task_test.go
@@ -1480,7 +1480,7 @@ func TestTaskPreburntRegistrationFee(t *testing.T) {
 				},
 				sendFromAddressRetErr: errors.New("test"),
 			},
-			wantErr: errors.New("failed to burn"),
+			wantErr: errors.New("burn"),
 		},
 		"send-preburnt-fee-err": {
 			args: args{
@@ -1502,7 +1502,7 @@ func TestTaskPreburntRegistrationFee(t *testing.T) {
 				sendFromAddressRetErr: nil,
 				burnTxnIDRet:          "test-id",
 			},
-			wantErr: errors.New("failed to send pre-burn-txid"),
+			wantErr: errors.New("send pre-burn-txid"),
 		},
 		"regArtTxId-empty-err": {
 			args: args{
@@ -1521,7 +1521,7 @@ func TestTaskPreburntRegistrationFee(t *testing.T) {
 				sendFromAddressRetErr: nil,
 				burnTxnIDRet:          "test-id",
 			},
-			wantErr: errors.New("regNFTTxid is empty"),
+			wantErr: errors.New("empty regNFTTxid"),
 		},
 		"success": {
 			args: args{
@@ -1753,7 +1753,7 @@ func TestTaskProbeImage(t *testing.T) {
 				},
 				probeImgErr: errors.New("test"),
 			},
-			wantErr: errors.New("failed to probe image"),
+			wantErr: errors.New("send image"),
 		},
 	}
 
@@ -1795,6 +1795,7 @@ func TestTaskProbeImage(t *testing.T) {
 			err = tc.args.task.probeImage(context.Background())
 			if tc.wantErr != nil {
 				assert.NotNil(t, err)
+				fmt.Printf("%v", err)
 				assert.True(t, strings.Contains(err.Error(), tc.wantErr.Error()))
 			} else {
 				fmt.Printf("%v", err)

--- a/walletnode/services/artworkregister/task_test.go
+++ b/walletnode/services/artworkregister/task_test.go
@@ -1234,7 +1234,7 @@ func TestTaskEncodeFingerprint(t *testing.T) {
 					TXID: "test-txid",
 				},
 			},
-			wantErr: errors.New("failed to decode image"),
+			wantErr: errors.New("decode image"),
 		},
 	}
 	for name, tc := range testCases {

--- a/walletnode/services/artworksearch/service.go
+++ b/walletnode/services/artworksearch/service.go
@@ -72,12 +72,12 @@ func NewService(config *Config, pastelClient pastel.Client, nodeClient node.Clie
 func (service *Service) RegTicket(ctx context.Context, RegTXID string) (*pastel.RegTicket, error) {
 	regTicket, err := service.pastelClient.RegTicket(ctx, RegTXID)
 	if err != nil {
-		return nil, fmt.Errorf("fetch: %s", err)
+		return nil, errors.Errorf("fetch: %w", err)
 	}
 
 	articketData, err := pastel.DecodeNFTTicket(regTicket.RegTicketData.NFTTicket)
 	if err != nil {
-		return nil, errors.Errorf("failed to convert NFT ticket: %w", err)
+		return nil, errors.Errorf("convert NFT ticket: %w", err)
 	}
 	regTicket.RegTicketData.NFTTicketData = *articketData
 
@@ -89,7 +89,7 @@ func (service *Service) GetThumbnail(ctx context.Context, regTicket *pastel.RegT
 	thumbnailHelper := thumbnail.New(service.pastelClient, service.nodeClient, service.config.ConnectToNodeTimeout)
 
 	if err := thumbnailHelper.Connect(ctx, 1, secInfo); err != nil {
-		return data, fmt.Errorf("connect Thumbnail helper : %s", err)
+		return data, fmt.Errorf("connect Thumbnail helper: %w", err)
 	}
 	defer thumbnailHelper.Close()
 

--- a/walletnode/services/artworksearch/thumbnail/thumbnail.go
+++ b/walletnode/services/artworksearch/thumbnail/thumbnail.go
@@ -83,7 +83,7 @@ func (t *thumbnailHelper) Connect(ctx context.Context, connections uint, secInfo
 		}
 
 		if err := node.Connect(ctx, t.timeOut, secInfo); err != nil {
-			log.WithContext(ctx).WithError(err).Error("Failed to connect to master node")
+			log.WithContext(ctx).WithError(err).Error("Connect to master node failed")
 			continue
 		}
 


### PR DESCRIPTION
1. unify logging
2. improve mesh creation
- dont call following code in goroutine:
```
 secondariesMtx.Lock()
 defer secondariesMtx.Unlock() 
 secondaries.Add(node)
```

- disconnect all nodes when meshing failed
3. Fixing some log code like 
return errors.Errorf("failed to encode jpeg: %w", err).WithField("filename", f.Name())
