### PR TITLE
fix wrong pastelID in authentication of p2p

### DIFF
--- a/p2p/kademlia/auth.go
+++ b/p2p/kademlia/auth.go
@@ -18,6 +18,7 @@ import (
 
 const (
 	timestampMarginDuration = 5 * time.Second
+	authAlgorithm           = "ed448"
 )
 
 // AuthHelper define a authentication help - that provide helper functions for authentication handshaking
@@ -86,7 +87,7 @@ func (ath *AuthHelper) VerifyPeer(ctx context.Context, authInfo *auth.PeerAuthIn
 	buf := new(bytes.Buffer)
 	_ = binary.Write(buf, binary.LittleEndian, authInfo.Timestamp.Unix())
 
-	if ok, err := ath.pastelClient.Verify(ctx, buf.Bytes(), string(authInfo.Signature), ath.secInfo.PastelID, ath.secInfo.Algorithm); err != nil || !ok {
+	if ok, err := ath.pastelClient.Verify(ctx, buf.Bytes(), string(authInfo.Signature), authInfo.PastelID, authAlgorithm); err != nil || !ok {
 		if err == nil {
 			err = errors.New("signature not match")
 		}
@@ -143,7 +144,7 @@ func (ath *AuthHelper) unsafeRefreshAuthInfo(ctx context.Context) error {
 	_ = binary.Write(buf, binary.LittleEndian, newTimestamp.Unix())
 
 	// Sign timestamp
-	newSignature, err := ath.pastelClient.Sign(ctx, buf.Bytes(), ath.secInfo.PastelID, ath.secInfo.PassPhrase, ath.secInfo.Algorithm)
+	newSignature, err := ath.pastelClient.Sign(ctx, buf.Bytes(), ath.secInfo.PastelID, ath.secInfo.PassPhrase, authAlgorithm)
 	if err != nil {
 		return err
 	}

--- a/p2p/test/auth/client/client.go
+++ b/p2p/test/auth/client/client.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/anacrolix/utp"
-	"github.com/otrv4/ed448"
 	"github.com/pastelnetwork/gonode/common/net/credentials/alts"
 	"github.com/pastelnetwork/gonode/p2p/kademlia"
 	"github.com/pastelnetwork/gonode/p2p/kademlia/auth"
@@ -29,8 +28,6 @@ func main() {
 		return
 	}
 
-	priKey, pubKey := common.GetKeys()
-
 	var conn net.Conn
 	var err error
 
@@ -48,14 +45,9 @@ func main() {
 	rawConn.SetDeadline(time.Now().Add(defaultConnDeadline))
 
 	secInfo := &alts.SecInfo{
-		PastelID: common.ClientPastelID,
+		PastelID: common.ClientB64PubKey,
 	}
-	fakePastelClient := &common.SecClient{
-		Client: nil,
-		Curve:  ed448.NewCurve(),
-		Pri:    priKey,
-		Pub:    pubKey,
-	}
+	fakePastelClient := common.NewSecClient()
 
 	authenticator := kademlia.NewAuthHelper(fakePastelClient, secInfo)
 	authHandshaker, _ := auth.NewClientHandshaker(ctx, authenticator, rawConn)

--- a/p2p/test/auth/common/common.go
+++ b/p2p/test/auth/common/common.go
@@ -19,44 +19,83 @@ const (
 	// fmt.Println(base64.StdEncoding.EncodeToString(pri[:]))
 	// fmt.Println(base64.StdEncoding.EncodeToString(pub[:]))
 
-	// B64PriKey - preconfig private key
-	B64PriKey = "MSTJkuJI7WV1H5UZ09FqCNCx8UNor18e89lSHxm3A7M1fuWTC7ED0e8Ss1t/KGzNfG3lz7dX8Rawc4aLFRchii2gRq049U/V3XXnV4zRRUZAb9hBx2XB+jF/YFQyT+gKfzfGjKkCb1EO+ee393yGPm/NSSmzvMv1brX5PfNeuCPtRZJAdvvxHCEw2rysJq9s"
-	// B64PubKey - preconfig public key
-	B64PubKey = "sHOGixUXIYotoEatOPVP1d1151eM0UVGQG/YQcdlwfoxf2BUMk/oCn83xoypAm9RDvnnt/d8hj4="
-	// ClientPastelID - pastelID of client
-	ClientPastelID = "client"
-	// ServerPastelID - pastelID of server
-	ServerPastelID = "server"
+	// ServerB64PriKey - preconfig private key
+	ServerB64PriKey = "MSTJkuJI7WV1H5UZ09FqCNCx8UNor18e89lSHxm3A7M1fuWTC7ED0e8Ss1t/KGzNfG3lz7dX8Rawc4aLFRchii2gRq049U/V3XXnV4zRRUZAb9hBx2XB+jF/YFQyT+gKfzfGjKkCb1EO+ee393yGPm/NSSmzvMv1brX5PfNeuCPtRZJAdvvxHCEw2rysJq9s"
+	// ServerB64PubKey - preconfig public key
+	ServerB64PubKey = "sHOGixUXIYotoEatOPVP1d1151eM0UVGQG/YQcdlwfoxf2BUMk/oCn83xoypAm9RDvnnt/d8hj4="
+
+	// ClientB64PriKey - preconfig private key
+	ClientB64PriKey = "ACb1SPfXNjBqYLk4JIkCTFlYQjDjYyBGVbMOxcOeKPjhWob22+nGIaNJM5icElP/VXrQf28A3hL0TLznDNDZfonyNOFe9FGTAO1dXU3SgszjA56XC1Jvp9FNCFtfEZ0ItSsAXVVg17lAh8lxOUEjXlqbuQxwEB6l37yzw9VGOCNhxGoimI551WSJ/w1n32Ov"
+	// ClientB64PubKey - preconfig public key
+	ClientB64PubKey = "9Ey85wzQ2X6J8jThXvRRkwDtXV1N0oLM4wOelwtSb6fRTQhbXxGdCLUrAF1VYNe5QIfJcTlBI14="
 )
-
-// GetKeys return a couple of (private/public) keys to sign/verify handshake authentication
-func GetKeys() (PriKey [144]byte, PubKey [56]byte) {
-	Priv, err := base64.StdEncoding.DecodeString(B64PriKey)
-	if err != nil {
-		panic("failed to decode Private key :" + err.Error())
-	}
-	copy(PriKey[:], Priv)
-
-	Pub, err := base64.StdEncoding.DecodeString(B64PubKey)
-	if err != nil {
-		panic("failed to decode Pub key :" + err.Error())
-	}
-	copy(PubKey[:], Pub)
-
-	return
-}
 
 // SecClient is implemented Sign/Verify functions
 type SecClient struct {
+	// Client is mock client
 	*pastelMock.Client
+	// Curve is a curve
 	Curve ed448.Curve
-	Pri   [144]byte
-	Pub   [56]byte
+	// ServerPri is Server private key
+	ServerPri [144]byte
+	// ServerPub is Server pub key
+	ServerPub [56]byte
+	// ClientPri is Client private key
+	ClientPri [144]byte
+	// ClientPub is Client pub key
+	ClientPub [56]byte
 }
 
+// NewSecClient return a SecClient
+func NewSecClient() *SecClient {
+	sec := &SecClient{
+		Client: nil,
+		Curve:  ed448.NewCurve(),
+	}
+
+	Priv, err := base64.StdEncoding.DecodeString(ServerB64PriKey)
+	if err != nil {
+		panic("failed to decode Private key :" + err.Error())
+	}
+	copy(sec.ServerPri[:], Priv)
+
+	Pub, err := base64.StdEncoding.DecodeString(ServerB64PubKey)
+	if err != nil {
+		panic("failed to decode Pub key :" + err.Error())
+	}
+	copy(sec.ServerPub[:], Pub)
+
+	Priv, err = base64.StdEncoding.DecodeString(ClientB64PriKey)
+	if err != nil {
+		panic("failed to decode Private key :" + err.Error())
+	}
+	copy(sec.ClientPri[:], Priv)
+
+	Pub, err = base64.StdEncoding.DecodeString(ClientB64PubKey)
+	if err != nil {
+		panic("failed to decode Pub key :" + err.Error())
+	}
+	copy(sec.ClientPub[:], Pub)
+
+	return sec
+}
+
+// // Sign signs data by the given pastelID and passphrase, if successful returns signature.
+// // Command `pastelid sign "text" "PastelID" "passphrase"` "algorithm"
+// // Algorithm is ed448[default] or legroast
+// Sign(ctx context.Context, data []byte, pastelID, passphrase string, algorithm string) (signature []byte, err error)
+
+// // Verify verifies signed data by the given its signature and pastelID, if successful returns true.
+// // Command `pastelid verify "text" "signature" "PastelID"`.
+// Verify(ctx context.Context, data []byte, signature, pastelID string, algorithm string) (ok bool, err error)
+
 // Sign a data
-func (c *SecClient) Sign(_ context.Context, data []byte, _, _ string, _ string) ([]byte, error) {
-	signature, ok := c.Curve.Sign(c.Pri, data)
+func (c *SecClient) Sign(_ context.Context, data []byte, pastelID string, _ string, _ string) ([]byte, error) {
+	pri := c.ServerPri
+	if pastelID == ClientB64PubKey {
+		pri = c.ClientPri
+	}
+	signature, ok := c.Curve.Sign(pri, data)
 	if !ok {
 		return nil, errors.New("sign failed")
 	}
@@ -65,7 +104,12 @@ func (c *SecClient) Sign(_ context.Context, data []byte, _, _ string, _ string) 
 }
 
 // Verify data + signature
-func (c *SecClient) Verify(_ context.Context, data []byte, signature, _ string, _ string) (ok bool, err error) {
+func (c *SecClient) Verify(_ context.Context, data []byte, signature, pastelID string, _ string) (ok bool, err error) {
+	pub := c.ServerPub
+	if pastelID == ClientB64PubKey {
+		pub = c.ClientPub
+	}
+
 	signatureData, err := base64.StdEncoding.DecodeString(signature)
 	if err != nil {
 		return false, errors.Errorf("decode failed %w", err)
@@ -73,7 +117,7 @@ func (c *SecClient) Verify(_ context.Context, data []byte, signature, _ string, 
 	var copiedSignature [112]byte
 	copy(copiedSignature[:], signatureData)
 
-	ok = c.Curve.Verify(copiedSignature, data, c.Pub)
+	ok = c.Curve.Verify(copiedSignature, data, pub)
 	return ok, nil
 }
 
@@ -84,11 +128,11 @@ func (c *SecClient) MasterNodesExtra(_ context.Context) (pastel.MasterNodes, err
 	return pastel.MasterNodes{
 		pastel.MasterNode{
 			ExtAddress: "127.0.0.1:1000", // port is not important here
-			ExtKey:     ServerPastelID,
+			ExtKey:     ServerB64PubKey,
 		},
 		pastel.MasterNode{
 			ExtAddress: "127.0.0.1:anyport",
-			ExtKey:     ClientPastelID, // port is not important here
+			ExtKey:     ClientB64PubKey, // port is not important here
 		},
 	}, nil
 }

--- a/p2p/test/auth/server/server.go
+++ b/p2p/test/auth/server/server.go
@@ -7,7 +7,6 @@ import (
 	"net"
 
 	"github.com/anacrolix/utp"
-	"github.com/otrv4/ed448"
 	"github.com/pastelnetwork/gonode/common/net/credentials/alts"
 	"github.com/pastelnetwork/gonode/p2p/kademlia"
 	"github.com/pastelnetwork/gonode/p2p/kademlia/auth"
@@ -26,8 +25,6 @@ func main() {
 		return
 	}
 
-	priKey, pubKey := common.GetKeys()
-
 	var conn net.Conn
 	var err error
 
@@ -40,15 +37,9 @@ func main() {
 	}
 
 	secInfo := &alts.SecInfo{
-		PastelID: common.ServerPastelID,
+		PastelID: common.ServerB64PubKey,
 	}
-
-	fakePastelClient := &common.SecClient{
-		Client: nil,
-		Curve:  ed448.NewCurve(),
-		Pri:    priKey,
-		Pub:    pubKey,
-	}
+	fakePastelClient := common.NewSecClient()
 
 	for {
 


### PR DESCRIPTION
Using wrong pastelID of receiver than sender in `func (ath *AuthHelper) VerifyPeer(ctx context.Context, authInfo *auth.PeerAuthIn`