### PR TITLE
[PSL-143] DDAndFingerprints structure change

### DIFF
--- a/pastel/fingerprint.go
+++ b/pastel/fingerprint.go
@@ -4,11 +4,8 @@ import (
 	"bytes"
 	"encoding/binary"
 	"math"
-	"reflect"
 	"strings"
 	"unsafe"
-
-	"github.com/DataDog/zstd"
 
 	"github.com/pastelnetwork/gonode/common/errors"
 )
@@ -42,13 +39,13 @@ func (fg Fingerprint) Bytes() []byte {
 	return output.Bytes()
 }
 
-// CompareFingerPrintAndScore returns nil if two FingerAndScores are equal
-func CompareFingerPrintAndScore(lhs *FingerAndScores, rhs *FingerAndScores) error {
-
-	//hash_of_candidate_image_file
+// CompareFingerPrintAndScore returns nil if two DDAndFingerprints are equal
+func CompareFingerPrintAndScore(lhs *DDAndFingerprints, rhs *DDAndFingerprints) error {
+	// -------------------WIP: PSL-142------------------------------------------------
+	/*//hash_of_candidate_image_file
 	if !reflect.DeepEqual(lhs.HashOfCandidateImageFile, rhs.HashOfCandidateImageFile) {
 		return errors.New("image hash do not match")
-	}
+	}*/
 
 	//is_likely_dupe
 	if lhs.IsLikelyDupe != rhs.IsLikelyDupe {
@@ -56,8 +53,8 @@ func CompareFingerPrintAndScore(lhs *FingerAndScores, rhs *FingerAndScores) erro
 	}
 
 	//overall_average_rareness_score
-	if !compareFloatWithPrecision(lhs.OverallAverageRarenessScore, rhs.OverallAverageRarenessScore, 7.0) {
-		return errors.Errorf("overall average rareness score do not match: lhs(%f) != rhs(%f)", lhs.OverallAverageRarenessScore, rhs.OverallAverageRarenessScore)
+	if !compareFloatWithPrecision(lhs.Score.OverallAverageRarenessScore, rhs.Score.OverallAverageRarenessScore, 7.0) {
+		return errors.Errorf("overall average rareness score do not match: lhs(%f) != rhs(%f)", lhs.Score.OverallAverageRarenessScore, rhs.Score.OverallAverageRarenessScore)
 	}
 
 	//is_rare_on_internet
@@ -71,16 +68,18 @@ func CompareFingerPrintAndScore(lhs *FingerAndScores, rhs *FingerAndScores) erro
 	}
 
 	//alternative_nsfw_scores
-	if err := CompareAlternativeNSFWScore(&lhs.AlternativeNSFWScore, &rhs.AlternativeNSFWScore); err != nil {
+	if err := CompareAlternativeNSFWScore(lhs.AlternateNSFWScores, rhs.AlternateNSFWScores); err != nil {
 		return errors.Errorf("alternative nsfw score do not match: %w", err)
 	}
 
 	//image_hashes
-	if err := CompareImageHashes(&lhs.PerceptualImageHashes, &rhs.PerceptualImageHashes); err != nil {
+	if err := CompareImageHashes(lhs.PerceptualImageHashes, rhs.PerceptualImageHashes); err != nil {
 		return errors.Errorf("image hashes do not match: %w", err)
 	}
 
-	lhsFingerprint, err := zstd.Decompress(nil, lhs.ZstdCompressedFingerprint)
+	// -------------------WIP: PSL-142------------------------------------------------
+
+	/*lhsFingerprint, err := zstd.Decompress(nil, lhs.ZstdCompressedFingerprint)
 	if err != nil {
 		return errors.Errorf("decompress lhs fingerprint: %w", err)
 	}
@@ -109,6 +108,8 @@ func CompareFingerPrintAndScore(lhs *FingerAndScores, rhs *FingerAndScores) erro
 			}
 		}
 	}
+	*/
+
 	return nil
 }
 

--- a/pastel/reg_ticket.go
+++ b/pastel/reg_ticket.go
@@ -69,45 +69,64 @@ type AlternativeNSFWScore struct {
 	Sexy    float32 `json:"sexy"`
 }
 
-// FingerAndScores represents structure of app ticket
-type FingerAndScores struct {
-	DupeDectectionSystemVersion                  string                `json:"dupe_dectection_system_version"`
-	HashOfCandidateImageFile                     string                `json:"hash_of_candidate_image_file"`
-	OverallAverageRarenessScore                  float32               `json:"overall_average_rareness_score"`
-	IsLikelyDupe                                 bool                  `json:"is_rare_on_internet"`
-	IsRareOnInternet                             bool                  `json:"is_likely_dupe"`
-	NumberOfPagesOfResults                       uint32                `json:"number_of_pages_of_results"`
-	MatchesFoundOnFirstPage                      uint32                `json:"matches_found_on_first_page"`
-	URLOfFirstMatchInPage                        string                `json:"url_of_first_match_in_page"`
-	OpenNSFWScore                                float32               `json:"open_nsfw_score"`
-	ZstdCompressedFingerprint                    []byte                `json:"zstd_compressed_fingerprint"`
-	AlternativeNSFWScore                         AlternativeNSFWScore  `json:"alternative_nsfw_score"`
-	PerceptualImageHashes                        PerceptualImageHashes `json:"perceptual_image_hashes"`
-	PerceptualHashOverlapCount                   uint32                `json:"perceptual_hash_overlap_count"`
-	NumberOfFingerprintsRequiringFurtherTesting1 uint32                `json:"number_of_fingerprints_requiring_further_testing_1"`
-	NumberOfFingerprintsRequiringFurtherTesting2 uint32                `json:"number_of_fingerprints_requiring_further_testing_2"`
-	NumberOfFingerprintsRequiringFurtherTesting3 uint32                `json:"number_of_fingerprints_requiring_further_testing_3"`
-	NumberOfFingerprintsRequiringFurtherTesting4 uint32                `json:"number_of_fingerprints_requiring_further_testing_4"`
-	NumberOfFingerprintsRequiringFurtherTesting5 uint32                `json:"number_of_fingerprints_requiring_further_testing_5"`
-	NumberOfFingerprintsRequiringFurtherTesting6 uint32                `json:"number_of_fingerprints_requiring_further_testing_6"`
-	NumberOfFingerprintsOfSuspectedDupes         uint32                `json:"number_of_fingerprints_of_suspected_dupes"`
-	PearsonMax                                   float32               `json:"pearson_max"`
-	SpearmanMax                                  float32               `json:"spearman_max"`
-	KendallMax                                   float32               `json:"kendall_max"`
-	HoeffdingMax                                 float32               `json:"hoeffding_max"`
-	MutualInformationMax                         float32               `json:"mutual_information_max"`
-	HsicMax                                      float32               `json:"hsic_max"`
-	XgbimportanceMax                             float32               `json:"xgbimportance_max"`
-	PearsonTop1BpsPercentile                     float32               `json:"pearson_top_1_bps_percentile"`
-	SpearmanTop1BpsPercentile                    float32               `json:"spearman_top_1_bps_percentile"`
-	KendallTop1BpsPercentile                     float32               `json:"kendall_top_1_bps_percentile"`
-	HoeffdingTop10BpsPercentile                  float32               `json:"hoeffding_top_10_bps_percentile"`
-	MutualInformationTop100BpsPercentile         float32               `json:"mutual_information_top_100_bps_percentile"`
-	HsicTop100BpsPercentile                      float32               `json:"hsic_top_100_bps_percentile"`
-	XgbimportanceTop100BpsPercentile             float32               `json:"xgbimportance_top_100_bps_percentile"`
-	CombinedRarenessScore                        float32               `json:"combined_rareness_score"`
-	XgboostPredictedRarenessScore                float32               `json:"xgboost_predicted_rareness_score"`
-	NnPredictedRarenessScore                     float32               `json:"nn_predicted_rareness_score"`
+type DDPercentiles struct {
+	PearsonTop1BpsPercentile             float32 `json:"pearson_top_1_bps_percentile"`
+	SpearmanTop1BpsPercentile            float32 `json:"spearman_top_1_bps_percentile"`
+	KendallTop1BpsPercentile             float32 `json:"kendall_top_1_bps_percentile"`
+	HoeffdingTop10BpsPercentile          float32 `json:"hoeffding_top_10_bps_percentile"`
+	MutualInformationTop100BpsPercentile float32 `json:"mutual_information_top_100_bps_percentile"`
+	HsicTop100BpsPercentile              float32 `json:"hsic_top_100_bps_percentile"`
+	XgbimportanceTop100BpsPercentile     float32 `json:"xgbimportance_top_100_bps_percentile"`
+}
+
+type DDFingerprintsStat struct {
+	NumberOfFingerprintsRequiringFurtherTesting1 uint32 `json:"number_of_fingerprints_requiring_further_testing_1"`
+	NumberOfFingerprintsRequiringFurtherTesting2 uint32 `json:"number_of_fingerprints_requiring_further_testing_2"`
+	NumberOfFingerprintsRequiringFurtherTesting3 uint32 `json:"number_of_fingerprints_requiring_further_testing_3"`
+	NumberOfFingerprintsRequiringFurtherTesting4 uint32 `json:"number_of_fingerprints_requiring_further_testing_4"`
+	NumberOfFingerprintsRequiringFurtherTesting5 uint32 `json:"number_of_fingerprints_requiring_further_testing_5"`
+	NumberOfFingerprintsRequiringFurtherTesting6 uint32 `json:"number_of_fingerprints_requiring_further_testing_6"`
+	NumberOfFingerprintsOfSuspectedDupes         uint32 `json:"number_of_fingerprints_of_suspected_dupes"`
+}
+
+type DDMaxes struct {
+	PearsonMax           float32 `json:"pearson_max"`
+	SpearmanMax          float32 `json:"spearman_max"`
+	KendallMax           float32 `json:"kendall_max"`
+	HoeffdingMax         float32 `json:"hoeffding_max"`
+	MutualInformationMax float32 `json:"mutual_information_max"`
+	HsicMax              float32 `json:"hsic_max"`
+	XgbimportanceMax     float32 `json:"xgbimportance_max"`
+}
+
+type DDScores struct {
+	CombinedRarenessScore         float32 `json:"combined_rareness_score"`
+	XgboostPredictedRarenessScore float32 `json:"xgboost_predicted_rareness_score"`
+	NnPredictedRarenessScore      float32 `json:"nn_predicted_rareness_score"`
+	OverallAverageRarenessScore   float32 `json:"overall_average_rareness_score"`
+}
+
+// DDAndFingerprints represents  the dd & fingerprints data returned by dd-service & SN
+type DDAndFingerprints struct {
+	Block                      string                 `json:"block"`
+	Principal                  string                 `json:"principal"`
+	DupeDetectionSystemVersion string                 `json:"dupe_detection_system_version"`
+	Fingerprints               Fingerprint            `json:"fingerprints"`
+	PastelRarenessScore        float32                `json:"pastel_rareness_score"`
+	IsLikelyDupe               bool                   `json:"is_likely_dupe"`
+	InternetRarenessScore      float32                `json:"internet_rareness_score"`
+	IsRareOnInternet           bool                   `json:"is_rare_on_internet"`
+	MatchesFoundOnFirstPage    uint32                 `json:"matches_found_on_first_page"`
+	NumberOfPagesOfResults     uint32                 `json:"number_of_pages_of_results"`
+	URLOfFirstMatchInPage      string                 `json:"url_of_first_match_in_page"`
+	OpenNSFWScore              float32                `json:"open_nsfw_score"`
+	PerceptualHashOverlapCount uint32                 `json:"perceptual_hash_overlap_count"`
+	AlternateNSFWScores        *AlternativeNSFWScore  `json:"alternate_nsfw_scores"`
+	PerceptualImageHashes      *PerceptualImageHashes `json:"perceptual_image_hashes"`
+	FingerprintsStat           *DDFingerprintsStat    `json:"fingerprints_stat"`
+	Maxes                      *DDMaxes               `json:"maxes"`
+	Percentile                 *DDPercentiles         `json:"percentile"`
+	Score                      *DDScores              `json:"score"`
 }
 
 // AppTicket represents pastel App ticket.


### PR DESCRIPTION
Data scehma changes around what dd-serice returns to SN. 
SN will compress it and return to WN
Upon receive on WN, We'd need to decompress and convert it back to the structure so  I made these changes first. 
Pls don't expect the build to succeed.
ref: https://pastel.wiki/en/Architecture/Components/TicketStructures