### PR TITLE
[NOJIRA] Fix MasterNode metadata

### DIFF
--- a/metadb/leader_transfer.go
+++ b/metadb/leader_transfer.go
@@ -125,7 +125,7 @@ func (s *service) getNextLeaderAddressAndID(ctx context.Context, nodes pastel.Ma
 	}
 
 	for _, node := range nodes {
-		address := node.Address
+		address := node.IPAddress
 		segments := strings.Split(address, ":")
 		if len(segments) != 2 {
 			log.MetaDB().WithContext(ctx).WithField("address", address).Error("leadershipTransfer: malformed address")

--- a/metadb/leader_transfer_test.go
+++ b/metadb/leader_transfer_test.go
@@ -38,12 +38,12 @@ func TestInitLeadershipTransferTrigger(t *testing.T) {
 				leaderCheckInterval:     time.Microsecond,
 				blockCountCheckInterval: time.Microsecond,
 				masterNodes: pastel.MasterNodes{
-					pastel.MasterNode{ExtP2P: "0.0.0.0:1234", Address: "127.0.0.1:9090"},
-					pastel.MasterNode{ExtP2P: "0.0.0.0:8784", Address: "127.0.0.1:9190"},
+					pastel.MasterNode{ExtP2P: "0.0.0.0:1234", IPAddress: "127.0.0.1:9090"},
+					pastel.MasterNode{ExtP2P: "0.0.0.0:8784", IPAddress: "127.0.0.1:9190"},
 				},
 				masterNodesExtra: pastel.MasterNodes{
-					pastel.MasterNode{ExtP2P: "0.0.0.0:1111", Address: "127.0.0.1:9090"},
-					pastel.MasterNode{ExtP2P: "1.1.1.1:1919", Address: "127.0.0.1:9190"},
+					pastel.MasterNode{ExtP2P: "0.0.0.0:1111", IPAddress: "127.0.0.1:9090"},
+					pastel.MasterNode{ExtP2P: "1.1.1.1:1919", IPAddress: "127.0.0.1:9190"},
 				},
 				masterNodesErr: nil,
 				blockCountErr:  nil,
@@ -60,8 +60,8 @@ func TestInitLeadershipTransferTrigger(t *testing.T) {
 				blockCountCheckInterval: time.Microsecond,
 				masterNodesErr:          errors.New("test"),
 				masterNodes: pastel.MasterNodes{
-					pastel.MasterNode{ExtP2P: "0.0.0.0:1234", Address: "127.0.0.1:9090"},
-					pastel.MasterNode{ExtP2P: "0.0.0.0:8784", Address: "127.0.0.1:9190"},
+					pastel.MasterNode{ExtP2P: "0.0.0.0:1234", IPAddress: "127.0.0.1:9090"},
+					pastel.MasterNode{ExtP2P: "0.0.0.0:8784", IPAddress: "127.0.0.1:9190"},
 				},
 			},
 			service: &service{
@@ -76,8 +76,8 @@ func TestInitLeadershipTransferTrigger(t *testing.T) {
 				masterNodesErr:          nil,
 				blockCountErr:           errors.New("test"),
 				masterNodes: pastel.MasterNodes{
-					pastel.MasterNode{ExtP2P: "0.0.0.0:1234", Address: "127.0.0.1:9090"},
-					pastel.MasterNode{ExtP2P: "0.0.0.0:8784", Address: "127.0.0.1:9190"},
+					pastel.MasterNode{ExtP2P: "0.0.0.0:1234", IPAddress: "127.0.0.1:9090"},
+					pastel.MasterNode{ExtP2P: "0.0.0.0:8784", IPAddress: "127.0.0.1:9190"},
 				},
 			},
 			service: &service{

--- a/pastel/masternode.go
+++ b/pastel/masternode.go
@@ -6,7 +6,7 @@ type MasterNodes []MasterNode
 // MasterNode represents pastel top masternode.
 type MasterNode struct {
 	Rank       string  `json:"rank"`
-	Address    string  `json:"address"`
+	IPAddress  string  `json:"IP:port"`
 	Payee      string  `json:"payee"`
 	Outpoint   string  `json:"outpoint"`
 	Fee        float64 `json:"fee"`


### PR DESCRIPTION
`Masternode top` command returns `IP:port` than `address`