### PR TITLE
Increase default dd-client grpc timeout to five minutes.  

### DIFF
--- a/dupedetection/ddclient/client.go
+++ b/dupedetection/ddclient/client.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	defaultConnectTimeout = 30 * time.Second
+	defaultConnectTimeout = 300 * time.Second
 )
 
 type client struct{}


### PR DESCRIPTION
This can be decreased later if it consumes too many resources, but can cause files to be deleted prematurely in dd-service if set too low.