### PR TITLE
These tweaks increase reliability of nft registration succeeding.

### DIFF
--- a/supernode/services/common/dupe_detection_handler.go
+++ b/supernode/services/common/dupe_detection_handler.go
@@ -223,7 +223,7 @@ func (h *DupeDetectionHandler) ProbeImage(_ context.Context, file *files.File, b
 			}
 
 			return nil
-		case <-time.After(60 * time.Second):
+		case <-time.After(600 * time.Second):
 			log.WithContext(ctx).Error("waiting for DDAndFingerprints from peers timeout")
 			err = errors.New("waiting for DDAndFingerprints timeout")
 			return nil

--- a/walletnode/services/common/config.go
+++ b/walletnode/services/common/config.go
@@ -6,7 +6,7 @@ const (
 	defaultNumberSuperNodes = 3
 
 	defaultConnectToNextNodeDelay = 400 * time.Millisecond
-	defaultAcceptNodesTimeout     = 180 * time.Second // = 3 * (2* ConnectToNodeTimeout)
+	defaultAcceptNodesTimeout     = 600 * time.Second // = 3 * (2* ConnectToNodeTimeout)
 	defaultConnectToNodeTimeout   = time.Second * 20
 )
 


### PR DESCRIPTION
Simple timeout increases in a couple places increase the reliability of nft registration (via reg and sense) succeeding.