### PR TITLE
Dd scan fixes

### DIFF
--- a/dupedetection/ddscan/config.go
+++ b/dupedetection/ddscan/config.go
@@ -8,9 +8,9 @@ const (
 	// DefaultOutputDir that dd-service uses to put new fingerprints
 	DefaultOutputDir = "output_files"
 	// DefaultDataFile that dd-service uses to store fingerprints
-	DefaultDataFile = "dupe_detection_image_fingerprint_database.sqlite"
+	DefaultDataFile = "registered_image_fingerprints_db.sqlite"
 	// DefaultSupportDir that dd-service uses for support files
-	// Should be ~/pastel_dupe_detection_service/support_files/dupe_detection_image_fingerprint_database.sqlite
+	// Should be ~/pastel_dupe_detection_service/support_files/registered_image_fingerprints_db.sqlite
 	DefaultSupportDir = "support_files"
 )
 

--- a/dupedetection/ddscan/service.go
+++ b/dupedetection/ddscan/service.go
@@ -334,13 +334,13 @@ func (s *service) tryToGetFingerprintFileFromHash(ctx context.Context, hash stri
 	if err != nil {
 		return nil, errors.Errorf("Error finding dd and fp file: %w", err)
 	}
+	//log.WithContext(ctx).WithField("rawFile:", rawFile).Debug("Got file from p2p")
+	// dec, err := utils.B64Decode(rawFile)
+	// if err != nil {
+	// 	return nil, errors.Errorf("decode data: %w", err)
+	// }
 
-	dec, err := utils.B64Decode(rawFile)
-	if err != nil {
-		return nil, errors.Errorf("decode data: %w", err)
-	}
-
-	decData, err := zstd.Decompress(nil, dec)
+	decData, err := zstd.Decompress(nil, rawFile)
 	if err != nil {
 		return nil, errors.Errorf("decompress: %w", err)
 	}

--- a/dupedetection/ddscan/service.go
+++ b/dupedetection/ddscan/service.go
@@ -420,6 +420,7 @@ func (s *service) runTask(ctx context.Context) error {
 		existsInDatabase, err := s.checkIfFingerprintExistsInDatabase(ctx, ddAndFpFromTicket.HashOfCandidateImageFile)
 		if existsInDatabase {
 			// log.DD().WithContext(ctx).WithField("hashOfCandidateImageFile", ddAndFpFromTicket.HashOfCandidateImageFile).Debug("Found hash of candidate image file already exists in database, not adding.")
+			latestBlockHeight = nftRegTickets[i].RegTicketData.NFTTicketData.BlockNum
 			continue
 		}
 		if err != nil {
@@ -515,6 +516,7 @@ func (s *service) runTask(ctx context.Context) error {
 		existsInDatabase, err := s.checkIfFingerprintExistsInDatabase(ctx, ddAndFpFromTicket.HashOfCandidateImageFile)
 		if existsInDatabase {
 			// log.DD().WithContext(ctx).WithField("hashOfCandidateImageFile", ddAndFpFromTicket.HashOfCandidateImageFile).Debug("Found hash of candidate image file already exists in database, not adding.")
+			latestBlockHeight = senseRegTickets[i].ActionTicketData.ActionTicketData.BlockNum
 			continue
 		}
 		if err != nil {
@@ -576,6 +578,7 @@ func (s *service) runTask(ctx context.Context) error {
 	}
 
 	s.latestBlockHeight = latestBlockHeight
+	log.DD().WithContext(ctx).WithField("latest blockheight", latestBlockHeight).Debugf("dd-scan successfully scanned to latest block height")
 
 	return nil
 }

--- a/dupedetection/ddscan/service.go
+++ b/dupedetection/ddscan/service.go
@@ -422,7 +422,9 @@ func (s *service) runTask(ctx context.Context) error {
 		if existsInDatabase {
 			// log.DD().WithContext(ctx).WithField("hashOfCandidateImageFile", ddAndFpFromTicket.HashOfCandidateImageFile).Debug("Found hash of candidate image file already exists in database, not adding.")
 			//can't directly update latest block height from here - if there's another ticket in this block we don't want to skip
-			lastKnownGoodHeight = nftRegTickets[i].RegTicketData.NFTTicketData.BlockNum
+			if nftRegTickets[i].RegTicketData.NFTTicketData.BlockNum > lastKnownGoodHeight {
+				lastKnownGoodHeight = nftRegTickets[i].RegTicketData.NFTTicketData.BlockNum
+			}
 			continue
 		}
 		if err != nil {
@@ -519,7 +521,9 @@ func (s *service) runTask(ctx context.Context) error {
 		if existsInDatabase {
 			// log.DD().WithContext(ctx).WithField("hashOfCandidateImageFile", ddAndFpFromTicket.HashOfCandidateImageFile).Debug("Found hash of candidate image file already exists in database, not adding.")
 			//can't directly update latest block height from here - if there's another ticket in this block we don't want to skip
-			lastKnownGoodHeight = senseRegTickets[i].ActionTicketData.ActionTicketData.BlockNum
+			if senseRegTickets[i].ActionTicketData.ActionTicketData.BlockNum > lastKnownGoodHeight {
+				lastKnownGoodHeight = senseRegTickets[i].ActionTicketData.ActionTicketData.BlockNum
+			}
 			continue
 		}
 		if err != nil {

--- a/dupedetection/ddscan/service.go
+++ b/dupedetection/ddscan/service.go
@@ -402,8 +402,10 @@ func (s *service) runTask(ctx context.Context) error {
 		for _, id := range ddFPIDs {
 			ddAndFpFromTicket, err = s.tryToGetFingerprintFileFromHash(ctx, id)
 			if err != nil {
-				break
+				log.WithContext(ctx).WithField("error", err).Debug("Could not get the fingerprint for this file hash")
+				continue
 			}
+			break
 		}
 		if ddAndFpFromTicket == nil {
 			log.WithContext(ctx).WithField("NFTRegTicket", nftRegTickets[i].RegTicketData.NFTTicketData).Warnf("None of the dd and fp id files for this nft reg ticket could be properly unmarshalled")
@@ -468,7 +470,7 @@ func (s *service) runTask(ctx context.Context) error {
 		return nil
 	}
 	for i := 0; i < len(senseRegTickets); i++ {
-		if senseRegTickets[i].ActionTicketData.ActionTicketData.BlockNum <= s.latestBlockHeight {
+		if senseRegTickets[i].ActionTicketData.CalledAt <= s.latestBlockHeight {
 			continue
 		}
 
@@ -479,7 +481,7 @@ func (s *service) runTask(ctx context.Context) error {
 		}
 		senseRegTickets[i].ActionTicketData.ActionTicketData = *decTicket
 
-		if senseRegTickets[i].ActionTicketData.Type != "sense" {
+		if senseRegTickets[i].ActionTicketData.ActionTicketData.ActionType != "sense" {
 			continue
 		}
 
@@ -494,11 +496,13 @@ func (s *service) runTask(ctx context.Context) error {
 		for _, id := range senseTicket.DDAndFingerprintsIDs {
 			ddAndFpFromTicket, err = s.tryToGetFingerprintFileFromHash(ctx, id)
 			if err != nil {
-				break
+				log.WithContext(ctx).WithField("error", err).Debug("Could not get the fingerprint for this file hash")
+				continue
 			}
+			break
 		}
 		if ddAndFpFromTicket == nil {
-			log.WithContext(ctx).WithField("senseTicket", senseTicket).Warnf("None of the dd and fp id files for thissense reg ticket could be properly unmarshalled")
+			log.WithContext(ctx).WithField("senseTicket", senseTicket).Warnf("None of the dd and fp id files for this sense reg ticket could be properly unmarshalled")
 			continue
 		}
 		if ddAndFpFromTicket.HashOfCandidateImageFile == "" {

--- a/pastel/action_ticket.go
+++ b/pastel/action_ticket.go
@@ -19,8 +19,8 @@ const (
 	ActionTypeCascade = "cascade"
 )
 
-// ActionTicketDatas is a collection of ActionTicketData (Note type here)
-type ActionTicketDatas []ActionTicketData
+// ActionTicketDatas is a collection of ActionRegTicket (Note type here)
+type ActionTicketDatas []ActionRegTicket
 
 // ActionRegTicket represents pastel registration ticket.
 type ActionRegTicket struct {

--- a/pastel/client.go
+++ b/pastel/client.go
@@ -268,6 +268,17 @@ func (client *client) RegTickets(ctx context.Context) (RegTickets, error) {
 	return tickets, nil
 }
 
+// RegTickets implements pastel.Client.RegTicketsFromBlockHeight
+func (client *client) RegTicketsFromBlockHeight(ctx context.Context, blockheight int32) (RegTickets, error) {
+	tickets := RegTickets{}
+
+	if err := client.callFor(ctx, &tickets, "tickets", "list", "nft", "all", blockheight); err != nil {
+		return nil, errors.Errorf("failed to get registration tickets with block height: %w", err)
+	}
+
+	return tickets, nil
+}
+
 func (client *client) GetBlockVerbose1(ctx context.Context, blkHeight int32) (*GetBlockVerbose1Result, error) {
 	result := &GetBlockVerbose1Result{}
 
@@ -539,6 +550,17 @@ func (client *client) ActionTickets(ctx context.Context) (ActionTicketDatas, err
 	tickets := ActionTicketDatas{}
 
 	if err := client.callFor(ctx, &tickets, "tickets", "list", "action"); err != nil {
+		return nil, errors.Errorf("failed to get action tickets: %w", err)
+	}
+
+	return tickets, nil
+}
+
+// ActionTicketsFromBlockHeight implements pastel.Client.ActionTicketsFromBlockHeight
+func (client *client) ActionTicketsFromBlockHeight(ctx context.Context, blockheight int32) (ActionTicketDatas, error) {
+	tickets := ActionTicketDatas{}
+
+	if err := client.callFor(ctx, &tickets, "tickets", "list", "action", "all", blockheight); err != nil {
 		return nil, errors.Errorf("failed to get action tickets: %w", err)
 	}
 

--- a/pastel/jsonrpc/jsonrpc.go
+++ b/pastel/jsonrpc/jsonrpc.go
@@ -351,7 +351,7 @@ func (client *rpcClient) CallRaw(request *RPCRequest) (*RPCResponse, error) {
 func (client *rpcClient) CallForWithContext(ctx context.Context, out interface{}, method string, params ...interface{}) error {
 	rpcResponse, err := client.CallWithContext(ctx, method, params...)
 
-	//log.WithContext(ctx).Debugf("%v", rpcResponse)
+	// log.WithContext(ctx).Debugf("-----GOT RPC RESPONSE FOR CALL: %+v\n", rpcResponse)
 	if err != nil {
 		return err
 	}
@@ -360,7 +360,9 @@ func (client *rpcClient) CallForWithContext(ctx context.Context, out interface{}
 		return fmt.Errorf("code: %d, message: %s", rpcResponse.Error.Code, rpcResponse.Error.Message)
 	}
 
-	return rpcResponse.GetObject(out)
+	err = rpcResponse.GetObject(out)
+	// log.WithContext(ctx).Debugf("-----CONVERTED RESPONSE FOR CALL: %+v\n", out)
+	return err
 }
 
 func (client *rpcClient) CallFor(out interface{}, method string, params ...interface{}) error {

--- a/pastel/pastel.go
+++ b/pastel/pastel.go
@@ -76,6 +76,10 @@ type Client interface {
 	// Command `tickets list art`.
 	RegTickets(ctx context.Context) (RegTickets, error)
 
+	// RegTicketsFromBlockHeight returns all NFT registration tickets higher than height <blockheight> or higher.
+	// Command `tickets list nft <height>`.
+	RegTicketsFromBlockHeight(ctx context.Context, blockheight int32) (RegTickets, error)
+
 	// GetBlockVerbose1 Return block info with verbose is 1
 	// Command `getblock height 1`
 	GetBlockVerbose1(ctx context.Context, blkHeight int32) (*GetBlockVerbose1Result, error)
@@ -149,6 +153,10 @@ type Client interface {
 	// ActionTickets returns action tickets similar to RegTickets, but for action tickets
 	// Command `tickets list action`
 	ActionTickets(ctx context.Context) (ActionTicketDatas, error)
+
+	// ActionTicketsFromBlockHeight returns action tickets similar to RegTickets, but for action tickets
+	// Command `tickets list action`
+	ActionTicketsFromBlockHeight(ctx context.Context, blockheight int32) (ActionTicketDatas, error)
 
 	// FindActionActByActionRegTxid returns the action activation ticket by ActionReg ticket txid
 	// Command `tickets find action-act <action-reg-ticket-txid>`

--- a/pastel/test/mock_client.go
+++ b/pastel/test/mock_client.go
@@ -203,7 +203,7 @@ func (client *Client) ListenOnRegTickets(ticket pastel.RegTickets, err error) *C
 	return client
 }
 
-// ListenOnRegTickets listening RegTickets and returns ticket and error from args
+// ListenOnRegTicketsFromBlockHeight listening RegTickets and returns ticket and error from args
 func (client *Client) ListenOnRegTicketsFromBlockHeight(ticket pastel.RegTickets, blockheight int, err error) *Client {
 	client.On(RegTicketsMethod, mock.Anything).Return(ticket, err)
 	return client

--- a/pastel/test/mock_client.go
+++ b/pastel/test/mock_client.go
@@ -33,6 +33,9 @@ const (
 	// RegTicketsMethod represent RegTickets name method
 	RegTicketsMethod = "RegTickets"
 
+	// RegTicketsFromBlockHeightMethod represent RegTicketsFromBlockHeight name method
+	RegTicketsFromBlockHeightMethod = "RegTicketsFromBlockHeight"
+
 	// GetBlockVerbose1Method represent GetBlockVerbose1 method
 	GetBlockVerbose1Method = "GetBlockVerbose1"
 
@@ -196,6 +199,12 @@ func (client *Client) ListenOnRegTicket(id string, ticket pastel.RegTicket, err 
 
 // ListenOnRegTickets listening RegTickets and returns ticket and error from args
 func (client *Client) ListenOnRegTickets(ticket pastel.RegTickets, err error) *Client {
+	client.On(RegTicketsMethod, mock.Anything).Return(ticket, err)
+	return client
+}
+
+// ListenOnRegTickets listening RegTickets and returns ticket and error from args
+func (client *Client) ListenOnRegTicketsFromBlockHeight(ticket pastel.RegTickets, blockheight int, err error) *Client {
 	client.On(RegTicketsMethod, mock.Anything).Return(ticket, err)
 	return client
 }

--- a/pastel/test/mock_client.go
+++ b/pastel/test/mock_client.go
@@ -205,7 +205,7 @@ func (client *Client) ListenOnRegTickets(ticket pastel.RegTickets, err error) *C
 
 // ListenOnRegTicketsFromBlockHeight listening RegTickets and returns ticket and error from args
 func (client *Client) ListenOnRegTicketsFromBlockHeight(ticket pastel.RegTickets, blockheight int, err error) *Client {
-	client.On(RegTicketsMethod, mock.Anything).Return(ticket, err)
+	client.On(RegTicketsMethod, blockheight, mock.Anything).Return(ticket, err)
 	return client
 }
 


### PR DESCRIPTION
Make sure dd-scan works and can get files into the sqlite database. (Functionally also stops repeated warning output)
Fix action ticket data so it can be decoded.