### PR TITLE
Removing dependency from rqlite/db wrapper

### DIFF
--- a/dupedetection/README.md
+++ b/dupedetection/README.md
@@ -41,11 +41,13 @@ mkdir -p /home/$USER/pastel_dupe_detection_service/support_files/mobilenet_v2_14
 
 Then, in the "support_files" directory, put the following files:
 
-* dupe_detection_image_fingerprint_database.sqlite (download and extract from: https://download.pastel.network/machine-learning/dupe_detection_image_fingerprint_database.zip )
+* dupe_detection_image_fingerprint_database.sqlite (download and extract from: https://download.pastel.network/machine-learning/registered_image_fingerprints_db.sqlite )
 
-* xgboost_dupe_classifier.model (download and extract from: https://download.pastel.network/machine-learning/xgboost_dupe_classifier.zip )
+* DupeDetector_gray.pth.tar (download from: https://download.pastel.network/machine-learning/DupeDetector_gray.pth.tar)
 
-* keras_dupe_classifier.model (this is actually a folder; download and extract from: https://download.pastel.network/machine-learning/keras_dupe_classifier.model.zip )
+* pca_bw.vt (download from: https://download.pastel.network/machine-learning/pca_bw.vt)
+
+* train_0_bw.hdf5 (download from: https://download.pastel.network/machine-learning/train_0_bw.hdf5)
 
 * config.ini
 ```ini
@@ -74,12 +76,12 @@ Clone dd-service source: https://github.com/pastelnetwork/dd-service
 #### Run dd-service:
 ```bash
 cd <path to dd-service>/dd-service
-python3 pastel_dupe_detection_daemon_v4.py
+python3 dupe_detection_server.py
 ```
 
 #### Run test API:
 ```bash
 cd cmd
-go run test.go -workDir /home/$USER/pastel_dupe_detection_service/
+go run test.go
 ```
 it takes about 2 minutes for the test end.

--- a/dupedetection/cmd/test.go
+++ b/dupedetection/cmd/test.go
@@ -27,6 +27,6 @@ func main() {
 
 	_, err = client.ImageRarenessScore(context.Background(), data, "png", "testBlockHash", "240669", "2022-03-31 16:55:28", "testPastelID", "jXYiHNqO9B7psxFQZb1thEgDNykZjL8GkHMZNPZx3iCYre1j3g0zHynlTQ9TdvY6dcRlYIsNfwIQ6nVXBSVJis", "jXpDb5K6S81ghCusMOXLP6k0RvqgFhkBJSFf6OhjEmpvCWGZiptRyRgfQ9cTD709sA58m5czpipFnvpoHuPX0F", "jXS9NIXHj8pd9mLNsP2uKgIh1b3EH2aq5dwupUF7hoaltTE8Zlf6R7Pke0cGr071kxYxqXHQmfVO5dA4jH0ejQ", false, "")
 	if err != nil {
-		panic("do ImageRarenessScore() error" + err.Error())
+		panic("do ImageRarenessScore() error: " + err.Error())
 	}
 }

--- a/hermes/service/hermes/service.go
+++ b/hermes/service/hermes/service.go
@@ -11,25 +11,14 @@ import (
 	"strings"
 	"time"
 
-<<<<<<< HEAD:hermes/service/hermes/service.go
-	"github.com/pastelnetwork/gonode/common/errgroup"
-
-=======
->>>>>>> 5196f8a0 (Removing dependency from rqlite/db wrapper):dupedetection/ddscan/service.go
 	"github.com/DataDog/zstd"
 	"github.com/jmoiron/sqlx"
+	"github.com/pastelnetwork/gonode/common/errgroup"
 	"github.com/pastelnetwork/gonode/common/errors"
 	"github.com/pastelnetwork/gonode/common/log"
 	"github.com/pastelnetwork/gonode/common/utils"
-<<<<<<< HEAD:hermes/service/hermes/service.go
-	svc "github.com/pastelnetwork/gonode/hermes/service"
-	"github.com/pastelnetwork/gonode/hermes/service/node"
-	"github.com/pastelnetwork/gonode/metadb/rqlite/command"
-	"github.com/pastelnetwork/gonode/metadb/rqlite/db"
-=======
 	"github.com/pastelnetwork/gonode/metadb/rqlite/command"
 	"github.com/pastelnetwork/gonode/p2p"
->>>>>>> 5196f8a0 (Removing dependency from rqlite/db wrapper):dupedetection/ddscan/service.go
 	"github.com/pastelnetwork/gonode/pastel"
 	"github.com/sbinet/npyio"
 	"gonum.org/v1/gonum/mat"
@@ -59,14 +48,8 @@ type dupeDetectionFingerprints struct {
 type service struct {
 	config             *Config
 	pastelClient       pastel.Client
-<<<<<<< HEAD:hermes/service/hermes/service.go
-	p2p                node.HermesP2PInterface
-	sn                 node.SNClientInterface
-	db                 *db.DB
-=======
 	p2pClient          p2p.Client
 	db                 *sqlx.DB
->>>>>>> 5196f8a0 (Removing dependency from rqlite/db wrapper):dupedetection/ddscan/service.go
 	isMasterNodeSynced bool
 	latestBlockHeight  int
 
@@ -274,16 +257,9 @@ func (s *service) getLatestFingerprint(ctx context.Context) (*dupeDetectionFinge
 	return ddFingerprint, nil
 }
 
-<<<<<<< HEAD:hermes/service/hermes/service.go
 func (s *service) checkIfFingerprintExistsInDatabase(_ context.Context, hash string) (bool, error) {
 	req := &command.Request{
 		Statements: []*command.Statement{
-=======
-func (s *service) checkIfFingerprintExistsInDatabase(ctx context.Context, hash string) (bool, error) {
-	stmt := &command.Statement{
-		Sql: getFingerprintFromHashStatement,
-		Parameters: []*command.Parameter{
->>>>>>> 5196f8a0 (Removing dependency from rqlite/db wrapper):dupedetection/ddscan/service.go
 			{
 				Value: &command.Parameter_S{
 					S: hash,

--- a/hermes/service/hermes/service_test.go
+++ b/hermes/service/hermes/service_test.go
@@ -11,8 +11,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jmoiron/sqlx/"
 	"github.com/pastelnetwork/gonode/common/errors"
-	"github.com/pastelnetwork/gonode/metadb/rqlite/db"
 	"github.com/pastelnetwork/gonode/pastel"
 	pastelMock "github.com/pastelnetwork/gonode/pastel/test"
 	"github.com/stretchr/testify/assert"
@@ -25,7 +25,7 @@ func prepareService(_ *testing.T) *service {
 	if err != nil {
 		panic(err.Error())
 	}
-	db, err := db.Open(tmpfile.Name(), true)
+	db, err := sqlx.DB.Open(tmpfile.Name(), true)
 	if err != nil {
 		panic("failed to open database")
 	}


### PR DESCRIPTION
Took an initial stab at removing the dependency of the RQLITE wrapper.

First impression is that we need the rqlite/command package for the structs. 

Possible improvements: 
1) Adding a light wrapper in the dd-scan folder that encapsulates all of the necessary code to use the sqlx library
2) Further remove the dependency to the command package and rewrite more of the code. 

