### PR TITLE
[PSL-710] p2p replication worker

### DIFF
--- a/integration/infra/docker-compose.yml
+++ b/integration/infra/docker-compose.yml
@@ -10,22 +10,22 @@ x-default: &default
   <<: *network
 
 services:
-  wn:
-    <<: *default
-    container_name: walletnode-1
-    hostname: walletnode-1
-    image: gonode-wn-service:0.1
-    environment:
-      - INTEGRATION_TEST_ENV=true
-    build:
-      context: ../..
-      dockerfile: ./integration/infra/wn.it.Dockerfile
-    command: sh -c "/app/pastelup start rq-service && /app/app --config-file=/configs/wn.yml --pastel-config-file=/configs/p0.conf"
-    ports:
-      - 18089:8089
-      - 15005:50051
-    volumes:
-      - ~/.pastel/rqfiles:/root/.pastel/rqfiles
+  # wn:
+  #   <<: *default
+  #   container_name: walletnode-1
+  #   hostname: walletnode-1
+  #   image: gonode-wn-service:0.1
+  #   environment:
+  #     - INTEGRATION_TEST_ENV=true
+  #   build:
+  #     context: ../..
+  #     dockerfile: ./integration/infra/wn.it.Dockerfile
+  #   command: sh -c "/app/pastelup start rq-service && /app/app --config-file=/configs/wn.yml --pastel-config-file=/configs/p0.conf"
+  #   ports:
+  #     - 18089:8089
+  #     - 15005:50051
+  #   volumes:
+  #     - ~/.pastel/rqfiles:/root/.pastel/rqfiles
   sn1:
     <<: *default
     container_name: snserver-1
@@ -39,6 +39,8 @@ services:
     command: sh -c "/app/pastelup start rq-service && /app/app --config-file=/configs/sn1.yml --pastel-config-file=/configs/p1.conf"
     ports:
       - 19090:9090
+    volumes:
+      - /home/mrrobot/integration/sn1:/root/.pastel/supernode/p2p-data
   sn2:
     <<: *default
     container_name: snserver-2
@@ -51,6 +53,8 @@ services:
     command: sh -c "/app/pastelup start rq-service && /app/app --config-file=/configs/sn2.yml --pastel-config-file=/configs/p2.conf"
     ports:
       - 19091:9090
+    volumes:
+      - /home/mrrobot/integration/sn2:/root/.pastel/supernode/p2p-data
   sn3:
     <<: *default
     container_name: snserver-3
@@ -63,6 +67,8 @@ services:
     command: sh -c "/app/pastelup start rq-service && /app/app --config-file=/configs/sn3.yml --pastel-config-file=/configs/p3.conf"
     ports:
       - 19092:9090
+    volumes:
+      - /home/mrrobot/integration/sn3:/root/.pastel/supernode/p2p-data
   sn4:
     <<: *default
     container_name: snserver-4
@@ -75,6 +81,8 @@ services:
     command: sh -c "/app/pastelup start rq-service && /app/app --config-file=/configs/sn4.yml --pastel-config-file=/configs/p4.conf"
     ports:
       - 19093:9090
+    volumes:
+      - /home/mrrobot/integration/sn4:/root/.pastel/supernode/p2p-data
   sn5:
     <<: *default
     container_name: snserver-5
@@ -84,11 +92,11 @@ services:
       - INTEGRATION_TEST_ENV=true
     depends_on:
       - sn1
-      - sn2
-      - sn3
     command: sh -c "/app/pastelup start rq-service && /app/app --config-file=/configs/sn4.yml --pastel-config-file=/configs/p5.conf"
     ports:
       - 19094:9090
+    volumes:
+      - /home/mrrobot/integration/sn5:/root/.pastel/supernode/p2p-data
   sn6:
     <<: *default
     container_name: snserver-6
@@ -98,11 +106,11 @@ services:
       - INTEGRATION_TEST_ENV=true
     depends_on:
       - sn1
-      - sn2
-      - sn3
     command: sh -c "/app/pastelup start rq-service && /app/app --config-file=/configs/sn4.yml --pastel-config-file=/configs/p6.conf"
     ports:
       - 19095:9090
+    volumes:
+      - /home/mrrobot/integration/sn6:/root/.pastel/supernode/p2p-data
   sn7:
     <<: *default
     container_name: snserver-7
@@ -112,52 +120,52 @@ services:
       - INTEGRATION_TEST_ENV=true
     depends_on:
       - sn1
-      - sn2
-      - sn3
     command: sh -c "/app/pastelup start rq-service && /app/app --config-file=/configs/sn7.yml --pastel-config-file=/configs/p7.conf"
     ports:
       - 19096:9090
-  dd-server-1:
-    <<: *default
-    container_name: dd-server-1
-    hostname: dd-server-1
-    image: gonode-dd-server:0.1 
-    build:
-      context: ../..
-      dockerfile: ./integration/infra/dd.it.Dockerfile
-    command: sh -c "/app/app"
-    ports:
-      - 51052:51052
-  dd-server-4:
-    <<: *default
-    container_name: dd-server-4
-    logging:
-      driver: none
-    hostname: dd-server-4
-    image: gonode-dd-server:0.1
-    command: sh -c "/app/app"
-    ports:
-      - 54052:51052
-  dd-server-2:
-    <<: *default
-    container_name: dd-server-2
-    hostname: dd-server-2
-    logging:
-      driver: none
-    image: gonode-dd-server:0.1
-    command: sh -c "/app/app"
-    ports:
-      - 52052:51052
-  dd-server-3:
-    <<: *default
-    container_name: dd-server-3
-    logging:
-      driver: none
-    hostname: dd-server-3
-    image: gonode-dd-server:0.1
-    command: sh -c "/app/app"
-    ports:
-      - 53052:51052
+    volumes:
+      - /home/mrrobot/integration/sn7:/root/.pastel/supernode/p2p-data
+  # dd-server-1:
+  #   <<: *default
+  #   container_name: dd-server-1
+  #   hostname: dd-server-1
+  #   image: gonode-dd-server:0.1 
+  #   build:
+  #     context: ../..
+  #     dockerfile: ./integration/infra/dd.it.Dockerfile
+  #   command: sh -c "/app/app"
+  #   ports:
+  #     - 51052:51052
+  # dd-server-4:
+  #   <<: *default
+  #   container_name: dd-server-4
+  #   logging:
+  #     driver: none
+  #   hostname: dd-server-4
+  #   image: gonode-dd-server:0.1
+  #   command: sh -c "/app/app"
+  #   ports:
+  #     - 54052:51052
+  # dd-server-2:
+  #   <<: *default
+  #   container_name: dd-server-2
+  #   hostname: dd-server-2
+  #   logging:
+  #     driver: none
+  #   image: gonode-dd-server:0.1
+  #   command: sh -c "/app/app"
+  #   ports:
+  #     - 52052:51052
+  # dd-server-3:
+  #   <<: *default
+  #   container_name: dd-server-3
+  #   logging:
+  #     driver: none
+  #   hostname: dd-server-3
+  #   image: gonode-dd-server:0.1
+  #   command: sh -c "/app/app"
+  #   ports:
+  #     - 53052:51052
   #rq-server-0:
   #  <<: *default
   #  container_name: rq-server-0
@@ -166,36 +174,36 @@ services:
   #  ports:
   #    - 49051:50051
   #  command: sh -c "./pastelup start rq-service && tail -f /root/.pastel/rqservice.log"
-  dd-server-5:
-    <<: *default
-    container_name: dd-server-5
-    logging:
-      driver: none
-    hostname: dd-server-5
-    image: gonode-dd-server:0.1
-    command: sh -c "/app/app"
-    ports:
-      - 55052:51052
-  dd-server-6:
-    <<: *default
-    container_name: dd-server-6
-    logging:
-      driver: none
-    hostname: dd-server-6
-    image: gonode-dd-server:0.1
-    command: sh -c "/app/app"
-    ports:
-      - 56052:51052
-  dd-server-7:
-    <<: *default
-    container_name: dd-server-7
-    logging:
-      driver: none
-    hostname: dd-server-7
-    image: gonode-dd-server:0.1
-    command: sh -c "/app/app"
-    ports:
-      - 57052:51052
+  # dd-server-5:
+  #   <<: *default
+  #   container_name: dd-server-5
+  #   logging:
+  #     driver: none
+  #   hostname: dd-server-5
+  #   image: gonode-dd-server:0.1
+  #   command: sh -c "/app/app"
+  #   ports:
+  #     - 55052:51052
+  # dd-server-6:
+  #   <<: *default
+  #   container_name: dd-server-6
+  #   logging:
+  #     driver: none
+  #   hostname: dd-server-6
+  #   image: gonode-dd-server:0.1
+  #   command: sh -c "/app/app"
+  #   ports:
+  #     - 56052:51052
+  # dd-server-7:
+  #   <<: *default
+  #   container_name: dd-server-7
+  #   logging:
+  #     driver: none
+  #   hostname: dd-server-7
+  #   image: gonode-dd-server:0.1
+  #   command: sh -c "/app/app"
+  #   ports:
+  #     - 57052:51052
   pasteld-1:
     <<: *default
     container_name: pasteld-1
@@ -215,6 +223,8 @@ services:
     container_name: pasteld-0
     hostname: pasteld-0
     image: gonode-pasteld:0.1
+    logging:
+      driver: none
     command: sh -c "/app/app"
     ports:
       - 29930:29932

--- a/integration/mock/pasteld_responses.go
+++ b/integration/mock/pasteld_responses.go
@@ -39,7 +39,25 @@ var masterNodeExtraResp = `{
 		"extP2P": "snserver-4:14445",
 		"extKey": "jXYegY26dJ1auzTj5xy1LSUHy3vEn91pMjQrMwAb97nVzH1859xBzbdiU1RsAhJiQ6Z8VbJwQeH5pwGbFAAaHc",
 		"extCfg": ""
-	  }
+	},
+	"t2734441a24ecfe8a699e62f3711311100c53cb534f40e6c885948515e410522-1": {
+		"extAddress": "snserver-5:14444",
+		"extP2P": "snserver-5:14445",
+		"extKey": "jXa7Ypp5fueoTboLYxAbH2ebaGLiQBRDF2u2PFAMYYGRjSMsEzn5sgSgyAy5xYpEfcMUqaUY6xZ8Qcxnn1pWAf",
+		"extCfg": ""
+	},
+	"s2734441a24ecfe8a699e62f3711311100c53cb534f40e6c885948515e410524-1": {
+		"extAddress": "snserver-6:14444",
+		"extP2P": "snserver-6:14445",
+		"extKey": "jXXQD8CjECcKknAUf5NHcCua8aqHhbq4vP5EyE6kCDvD6EWpnbjaUe8VH9ZVpvj8n85hkMtDZyPqrwJXPwYUBi",
+		"extCfg": ""
+	},
+	"s2734441a24ecfe8a699e62f3711311100c53cb534f40e6c885948515e410524-1": {
+		"extAddress": "snserver-7:14444",
+		"extP2P": "snserver-7:14445",
+		"extKey": "jXYqgELnZQUSC2D5ZKPzVxaJwDLKC2NAzTzvEkR5EXU3od7xDJH9JgsMWvU6FoYQaBVP489A1y7qw756m8Er1S",
+		"extCfg": ""
+	},
   }`
 var masterNodesTopResp = `{
 	"158978": [
@@ -93,6 +111,45 @@ var masterNodesTopResp = `{
 		"extAddress": "snserver-4:14444",
 		"extP2P": "snserver-4:14445",
 		"extKey": "jXYegY26dJ1auzTj5xy1LSUHy3vEn91pMjQrMwAb97nVzH1859xBzbdiU1RsAhJiQ6Z8VbJwQeH5pwGbFAAaHc",
+		"extCfg": ""
+	  },
+	  {
+		"rank": "5",
+		"IP:port": "snserver-5:19933",
+		"protocol": 170008,
+		"outpoint": "t2734441a24ecfe8a699e62f3711311100c53cb534f40e6c885948515e410522-1",
+		"payee": "vPo1skbEb46hq9WWjKyamLhoc1pSmDoa6xo",
+		"lastseen": 0,
+		"activeseconds": -1640641036,
+		"extAddress": "snserver-5:14444",
+		"extP2P": "snserver-5:14445",
+		"extKey": "jXa7Ypp5fueoTboLYxAbH2ebaGLiQBRDF2u2PFAMYYGRjSMsEzn5sgSgyAy5xYpEfcMUqaUY6xZ8Qcxnn1pWAf",
+		"extCfg": ""
+	  },
+	  {
+		"rank": "6",
+		"IP:port": "snserver-6:19933",
+		"protocol": 170008,
+		"outpoint": "a2734441a24ecfe8a699e62f3711311100c53cb534f40e6c885948515e410521-1",
+		"payee": "sPo1skbEb46hq9WWjKyamLhoc1pSmDoa6xo",
+		"lastseen": 0,
+		"activeseconds": -1640641036,
+		"extAddress": "snserver-6:14444",
+		"extP2P": "snserver-6:14445",
+		"extKey": "jXXQD8CjECcKknAUf5NHcCua8aqHhbq4vP5EyE6kCDvD6EWpnbjaUe8VH9ZVpvj8n85hkMtDZyPqrwJXPwYUBi",
+		"extCfg": ""
+	  },
+	  {
+		"rank": "7",
+		"IP:port": "snserver-7:19933",
+		"protocol": 170008,
+		"outpoint": "s2734441a24ecfe8a699e62f3711311100c53cb534f40e6c885948515e410524-1",
+		"payee": "uPo1skbEb46hq9WWjKyamLhoc1pSmDoa6xo",
+		"lastseen": 0,
+		"activeseconds": -1640641036,
+		"extAddress": "snserver-7:14444",
+		"extP2P": "snserver-7:14445",
+		"extKey": "jXYqgELnZQUSC2D5ZKPzVxaJwDLKC2NAzTzvEkR5EXU3od7xDJH9JgsMWvU6FoYQaBVP489A1y7qw756m8Er1S",
 		"extCfg": ""
 	  }
 	]

--- a/p2p/kademlia/bootstrap.go
+++ b/p2p/kademlia/bootstrap.go
@@ -216,7 +216,7 @@ func (s *DHT) Bootstrap(ctx context.Context, bootstrapIPs string) error {
 
 				if len(response.Sender.ID) != len(s.ht.self.ID) {
 					log.P2P().WithContext(ctx).WithField("sender-id", string(response.Sender.ID)).
-						WithField("self-id", string(s.ht.self.ID)).Warn("self ID && sender ID len don't match")
+						WithField("self-id", string(s.ht.self.ID)).Error("self ID && sender ID len don't match")
 
 					continue
 				}

--- a/p2p/kademlia/dht.go
+++ b/p2p/kademlia/dht.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pastelnetwork/gonode/common/storage"
 	"github.com/pastelnetwork/gonode/common/storage/memory"
 	"github.com/pastelnetwork/gonode/common/utils"
+	"github.com/pastelnetwork/gonode/p2p/kademlia/domain"
 	"github.com/pastelnetwork/gonode/pastel"
 	"golang.org/x/crypto/sha3"
 )
@@ -24,22 +25,22 @@ var (
 	defaultNetworkPort = 4445
 	defaultRefreshTime = time.Second * 3600
 	defaultPingTime    = time.Second * 10
-	defaultUpdateTime  = time.Minute * 10
 )
 
 // DHT represents the state of the local node in the distributed hash table
 type DHT struct {
-	ht           *HashTable       // the hashtable for routing
-	options      *Options         // the options of DHT
-	network      *Network         // the network of DHT
-	store        Store            // the storage of DHT
-	done         chan struct{}    // distributed hash table is done
-	cache        storage.KeyValue // store bad bootstrap addresses
-	pastelClient pastel.Client
-	externalIP   string
-	mtx          sync.Mutex
-	authHelper   *AuthHelper
-	ignorelist   *BanList
+	ht                   *HashTable       // the hashtable for routing
+	options              *Options         // the options of DHT
+	network              *Network         // the network of DHT
+	store                Store            // the storage of DHT
+	done                 chan struct{}    // distributed hash table is done
+	cache                storage.KeyValue // store bad bootstrap addresses
+	pastelClient         pastel.Client
+	externalIP           string
+	mtx                  sync.Mutex
+	authHelper           *AuthHelper
+	ignorelist           *BanList
+	nodeReplicationTimes map[string]*domain.NodeReplicationInfo
 }
 
 // Options contains configuration options for the local node
@@ -74,14 +75,24 @@ func NewDHT(ctx context.Context, store Store, pc pastel.Client, secInfo *alts.Se
 	if options.Port <= 0 {
 		options.Port = defaultNetworkPort
 	}
+	info, err := store.GetAllReplicationInfo(ctx)
+	if err != nil {
+		log.P2P().WithContext(ctx).WithError(err).Errorf("get all replicationInfo failed")
+	}
+
+	replicationMap := make(map[string]*domain.NodeReplicationInfo)
+	for _, v := range info {
+		replicationMap[string(v.ID)] = &v
+	}
 
 	s := &DHT{
-		store:        store,
-		options:      options,
-		pastelClient: pc,
-		done:         make(chan struct{}),
-		cache:        memory.NewKeyValue(),
-		ignorelist:   NewBanList(ctx),
+		store:                store,
+		options:              options,
+		pastelClient:         pc,
+		done:                 make(chan struct{}),
+		cache:                memory.NewKeyValue(),
+		ignorelist:           NewBanList(ctx),
+		nodeReplicationTimes: replicationMap,
 	}
 
 	if options.ExternalIP != "" {
@@ -139,58 +150,6 @@ func (s *DHT) getExternalIP() (string, error) {
 	return externalIP, nil
 }
 
-// StartReplication starts replication
-func (s *DHT) StartReplication(ctx context.Context) error {
-	log.P2P().WithContext(ctx).Info("replication worker started")
-
-	for {
-		select {
-		case <-time.After(defaultUpdateTime):
-			s.Replicate(ctx)
-		case <-ctx.Done():
-			log.P2P().WithContext(ctx).Error("closing replication worker")
-			return nil
-		}
-	}
-}
-
-// Replicate replicates the data
-func (s *DHT) Replicate(ctx context.Context) {
-	for i := 0; i < B; i++ {
-		if time.Since(s.ht.refreshTime(i)) > defaultRefreshTime {
-			// refresh the bucket by iterative find node
-			id := s.ht.randomIDFromBucket(K)
-			if _, err := s.iterate(ctx, IterateFindNode, id, nil); err != nil {
-				log.P2P().WithContext(ctx).WithError(err).Error("replicate iterate find node failed")
-			}
-		}
-	}
-
-	// replication
-	replicationKeys := s.store.GetKeysForReplication(ctx)
-	log.P2P().WithContext(ctx).WithField("repkey", len(replicationKeys)).Info("replication keys")
-	for _, key := range replicationKeys {
-		value, err := s.store.Retrieve(ctx, key)
-		if err != nil {
-			log.P2P().WithContext(ctx).WithError(err).Error("replicate store retrieve failed")
-			continue
-		}
-
-		if value != nil {
-			// iterate store the value
-			if _, err := s.iterate(ctx, IterateStore, key, value); err != nil {
-				log.P2P().WithContext(ctx).WithError(err).Error("replicate iterate store data failed")
-			} else {
-				if err := s.store.UpdateKeyReplication(ctx, key); err != nil {
-					log.P2P().WithContext(ctx).WithError(err).Error("replicate update key replication failed")
-				}
-			}
-		}
-	}
-
-	log.P2P().WithContext(ctx).Info("Replication done")
-}
-
 // Start the distributed hash table
 func (s *DHT) Start(ctx context.Context) error {
 	// start the network
@@ -198,7 +157,7 @@ func (s *DHT) Start(ctx context.Context) error {
 		return fmt.Errorf("start network: %v", err)
 	}
 
-	go s.StartReplication(ctx)
+	go s.StartReplicationWorker(ctx)
 
 	return nil
 }
@@ -589,6 +548,12 @@ func (s *DHT) addNode(ctx context.Context, node *Node) *Node {
 	if s.ht.hasBucketNode(index, node.ID) {
 		s.ht.refreshNode(node.ID)
 		return nil
+	}
+
+	if err := s.updateReplicationNode(ctx, node.ID, node.IP, node.Port, true); err != nil {
+		log.P2P().WithContext(ctx).WithField("node-id", string(node.ID)).WithField("node-ip", node.IP).WithError(err).Error("update replication node failed")
+	} else {
+		log.P2P().WithContext(ctx).WithField("node-id", string(node.ID)).WithField("node-ip", node.IP).Info("adding new node")
 	}
 
 	s.ht.mutex.Lock()

--- a/p2p/kademlia/domain/domain.go
+++ b/p2p/kademlia/domain/domain.go
@@ -1,0 +1,15 @@
+package domain
+
+import "time"
+
+// NodeReplicationInfo is the struct for replication info
+type NodeReplicationInfo struct {
+	LastReplicatedAt *time.Time `json:"last_replicated,omitempty"`
+	UpdatedAt        time.Time  `json:"updated_at"`
+	CreatedAt        time.Time  `json:"created_at"`
+	Active           bool       `json:"active"`
+	IP               string     `json:"ip"`
+	Port             int        `json:"port"`
+	ID               []byte     `json:"id"`
+	IsAdjusted       bool       `json:"is_adjusted"`
+}

--- a/p2p/kademlia/hashtable.go
+++ b/p2p/kademlia/hashtable.go
@@ -262,7 +262,7 @@ func (*HashTable) bucketIndex(id1 []byte, id2 []byte) int {
 		}
 	}
 
-	// only happen during bootstrapping
+	// only happen during bootstrap ping
 	return 0
 }
 

--- a/p2p/kademlia/replication.go
+++ b/p2p/kademlia/replication.go
@@ -1,0 +1,313 @@
+package kademlia
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/btcsuite/btcutil/base58"
+
+	"github.com/pastelnetwork/gonode/common/errors"
+	"github.com/pastelnetwork/gonode/common/log"
+	"github.com/pastelnetwork/gonode/p2p/kademlia/domain"
+)
+
+var (
+	// defaultReplicationTime is the default time for replication - in case lastReplicated is nil
+	// it will be used as the lastReplicated time
+	defaultReplicationTime = time.Hour * 24 * 730 // 2 year
+
+	// defaultReplicationInterval is the default interval for replication.
+	defaultReplicationInterval = time.Minute * 5
+
+	// nodeShowUpDeadline is the time after which the node will considered to be permeant offline
+	// we'll adjust the keys once the node is permeant offline
+	nodeShowUpDeadline = time.Minute * 35
+
+	// check for active & inactive nodes after this interval
+	checkNodeActivityInterval = time.Minute * 3
+)
+
+// StartReplicationWorker starts replication
+func (s *DHT) StartReplicationWorker(ctx context.Context) error {
+	log.P2P().WithContext(ctx).Info("replication worker started")
+
+	go s.checkNodeActivity(ctx)
+
+	for {
+		select {
+		case <-time.After(defaultReplicationInterval):
+			s.Replicate(ctx)
+		case <-ctx.Done():
+			log.P2P().WithContext(ctx).Error("closing replication worker")
+			return nil
+		}
+	}
+}
+
+func (s *DHT) updateReplicationNode(ctx context.Context, nodeID []byte, ip string, port int, isActive bool) error {
+	if info, ok := s.nodeReplicationTimes[string(nodeID)]; ok {
+		info.Active = isActive
+		info.UpdatedAt = time.Now()
+		info.IP = ip
+		info.Port = port
+		info.ID = nodeID
+
+		if err := s.store.UpdateReplicationInfo(ctx, *info); err != nil {
+			log.P2P().WithContext(ctx).WithError(err).WithField("node_id", string(nodeID)).WithField("ip", ip).Error("failed to add replication info")
+			return err
+		}
+
+	} else {
+		info := &domain.NodeReplicationInfo{
+			UpdatedAt: time.Now(),
+			Active:    isActive,
+			IP:        ip,
+			Port:      port,
+			ID:        nodeID,
+		}
+
+		s.nodeReplicationTimes[string(nodeID)] = info
+
+		if err := s.store.AddReplicationInfo(ctx, *info); err != nil {
+			log.P2P().WithContext(ctx).WithError(err).WithField("node_id", string(nodeID)).WithField("ip", ip).Error("failed to add replication info")
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (s *DHT) updateLastReplicated(ctx context.Context, nodeID []byte, timestamp time.Time) error {
+	info := s.nodeReplicationTimes[string(nodeID)]
+	if info == nil {
+		return errors.New("node not found")
+	}
+
+	info.LastReplicatedAt = &timestamp
+
+	s.nodeReplicationTimes[string(nodeID)] = info
+
+	if err := s.store.UpdateReplicationInfo(ctx, *info); err != nil {
+		log.P2P().WithContext(ctx).WithError(err).WithField("node_id", string(nodeID)).Error("failed to update replication info")
+	}
+
+	return nil
+}
+
+// Replicate is called periodically by the replication worker to replicate the data across the network by refreshing the buckets
+// it iterates over the node replication Info map and replicates the data to the nodes that are active
+func (s *DHT) Replicate(ctx context.Context) {
+	log.P2P().WithContext(ctx).Info("replicating data")
+
+	for i := 0; i < B; i++ {
+		if time.Since(s.ht.refreshTime(i)) > defaultRefreshTime {
+			// refresh the bucket by iterative find node
+			id := s.ht.randomIDFromBucket(K)
+			if _, err := s.iterate(ctx, IterateFindNode, id, nil); err != nil {
+				log.P2P().WithContext(ctx).WithError(err).Error("replicate iterate find node failed")
+			}
+		}
+	}
+
+	for nodeID, info := range s.nodeReplicationTimes {
+		logEntry := log.P2P().WithContext(ctx).WithField("rep-ip", info.IP).WithField("rep-id", nodeID)
+		if !info.Active {
+			adjustNodeKeys := isNodeGoneAndShouldBeAdjusted(info.LastReplicatedAt, info.IsAdjusted)
+			if adjustNodeKeys {
+				if err := s.adjustNodeKeys(ctx, *info); err != nil {
+					logEntry.WithError(err).Error("failed to adjust node keys")
+				} else {
+					info.IsAdjusted = true
+					info.UpdatedAt = time.Now()
+					s.nodeReplicationTimes[string(nodeID)] = info
+
+					if err := s.store.UpdateReplicationInfo(ctx, *info); err != nil {
+						logEntry.WithError(err).Error("failed to update replication info, set isAdjusted to true")
+					} else {
+						logEntry.Info("set isAdjusted to true")
+					}
+				}
+			}
+
+			logEntry.Info("replication node not active, skipping over it.")
+			continue
+		}
+
+		from := time.Now().Add(-defaultReplicationTime)
+		if info.LastReplicatedAt != nil {
+			from = *info.LastReplicatedAt
+		}
+
+		logEntry.WithField("from", from.String()).Info("replication from")
+		replicationKeys := s.store.GetKeysForReplication(ctx, from)
+		now := time.Now()
+		logEntry = logEntry.WithField("len-rep-keys", len(replicationKeys))
+		logEntry.Info("replication keys")
+
+		if len(replicationKeys) == 0 {
+			continue
+		}
+
+		for _, key := range replicationKeys {
+			ignores := s.ignorelist.ToNodeList()
+			nodeList := s.ht.closestContacts(6, key, ignores)
+
+			n := &Node{ID: []byte(nodeID), IP: info.IP, Port: info.Port}
+			if !nodeList.Exists(n) {
+				// the node is not supposed to hold this key as its not in 6 closest contacts
+				continue
+			}
+			logEntry.WithField("key", base58.Encode(key)).WithField("ip", info.IP).Info("this key is supposed to be hold by this node")
+
+			value, err := s.store.Retrieve(ctx, key)
+			if err != nil {
+				log.P2P().WithContext(ctx).WithError(err).Error("replicate store retrieve failed")
+				continue
+			}
+
+			if value != nil {
+				request := &StoreDataRequest{Data: value}
+				response, err := s.sendStoreData(ctx, n, request)
+				if err != nil {
+					logEntry.WithError(err).Error("replicate store data failed")
+				} else if response.Status.Result != ResultOk {
+					logEntry.WithError(errors.New(response.Status.ErrMsg)).Error("reply replicate store data failed")
+				} else {
+					logEntry.Info("replicate store data success")
+				}
+			}
+		}
+
+		if err := s.updateLastReplicated(ctx, []byte(nodeID), now); err != nil {
+			logEntry.Error("replicate update lastReplicated failed")
+		}
+
+	}
+
+	log.P2P().WithContext(ctx).Info("Replication done")
+}
+
+func (s *DHT) adjustNodeKeys(ctx context.Context, info domain.NodeReplicationInfo) error {
+	logEntry := log.P2P().WithContext(ctx).WithField("rep-ip", info.IP).WithField("rep-id", info.ID)
+
+	from := time.Now().Add(-defaultReplicationTime)
+	logEntry.WithField("from", from.String()).Info("adjusting node keys")
+
+	replicationKeys := s.store.GetKeysForReplication(ctx, from)
+	logEntry = logEntry.WithField("len-rep-keys", len(replicationKeys))
+	logEntry.Info("replication keys")
+
+	for _, key := range replicationKeys {
+
+		// prepare ignored nodes list but remove the node we are adjusting
+		// because we want to find if this node was supposed to hold this key
+		ignores := s.ignorelist.ToNodeList()
+		var updatedIgnored []*Node
+		for _, ignore := range ignores {
+			if string(ignore.ID) != string(info.ID) {
+				updatedIgnored = append(updatedIgnored, ignore)
+			}
+		}
+
+		// get closest contacts to the key
+		nodeList := s.ht.closestContacts(6, key, updatedIgnored)
+
+		// check if the node that is gone was supposed to hold the key
+		n := &Node{ID: []byte(info.ID), IP: info.IP, Port: info.Port}
+		if !nodeList.Exists(n) {
+			// the node is not supposed to hold this key as its not in 6 closest contacts
+			continue
+		}
+		logEntry.WithField("key", base58.Encode(key)).WithField("ip", info.IP).Info("this key is supposed to be hold by this node")
+
+		// get the value
+		value, err := s.store.Retrieve(ctx, key)
+		if err != nil {
+			log.P2P().WithContext(ctx).WithError(err).Error("replicate store retrieve failed")
+			continue
+		}
+
+		key := s.hashKey(value)
+
+		// iterative store the data
+		if _, err := s.iterate(ctx, IterateStore, key, value); err != nil {
+			log.WithContext(ctx).WithError(err).Error("replicate iterate data store failure")
+			continue
+		}
+	}
+
+	info.IsAdjusted = true
+	info.UpdatedAt = time.Now()
+
+	if err := s.store.UpdateReplicationInfo(ctx, info); err != nil {
+		return fmt.Errorf("replicate update isAdjusted failed: %v", err)
+	} else {
+		logEntry.Info("isAdjusted success")
+	}
+
+	return nil
+}
+
+func isNodeGoneAndShouldBeAdjusted(lastReplicated *time.Time, isAlreadyAdjusted bool) bool {
+	if lastReplicated == nil {
+		return false
+	}
+
+	return time.Since(*lastReplicated) > nodeShowUpDeadline && !isAlreadyAdjusted
+}
+
+// checkNodeActivity keeps track of active nodes - the idea here is to ping nodes periodically and mark them as inactive if they don't respond
+func (s *DHT) checkNodeActivity(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(checkNodeActivityInterval): // Adjust the interval as needed
+			for nodeID, info := range s.nodeReplicationTimes {
+				// new a ping request message
+				node := &Node{
+					ID:   []byte(nodeID),
+					IP:   info.IP,
+					Port: info.Port,
+				}
+
+				request := s.newMessage(Ping, node, nil)
+				// new a context with timeout
+				ctx, cancel := context.WithTimeout(ctx, defaultPingTime)
+				defer cancel()
+
+				// invoke the request and handle the response
+				_, err := s.network.Call(ctx, request)
+				if err != nil && info.Active {
+					log.P2P().WithContext(ctx).WithError(err).WithField("ip", info.IP).WithField("node_id", string(nodeID)).
+						Error("failed to ping node, setting node to inactive")
+
+					info.Active = false
+					info.UpdatedAt = time.Now()
+					s.nodeReplicationTimes[string(nodeID)] = info
+
+					if err := s.store.UpdateReplicationInfo(ctx, *info); err != nil {
+						log.P2P().WithContext(ctx).WithError(err).WithField("ip", info.IP).WithField("node_id", string(nodeID)).Error("failed to update replication info, node is inactive")
+					}
+
+				} else if err == nil {
+					log.P2P().WithContext(ctx).WithField("ip", info.IP).WithField("node_id", string(nodeID)).Info("node is active")
+
+					if !info.Active {
+						log.P2P().WithContext(ctx).WithField("ip", info.IP).WithField("node_id", string(nodeID)).Info("node found to be active again")
+
+						info.Active = true
+						info.IsAdjusted = false
+						info.UpdatedAt = time.Now()
+						s.nodeReplicationTimes[string(nodeID)] = info
+
+						if err := s.store.UpdateReplicationInfo(ctx, *info); err != nil {
+							log.P2P().WithContext(ctx).WithError(err).WithField("ip", info.IP).WithField("node_id", string(nodeID)).Error("failed to update replication info, node is active")
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/p2p/kademlia/replication.go
+++ b/p2p/kademlia/replication.go
@@ -247,9 +247,9 @@ func (s *DHT) adjustNodeKeys(ctx context.Context, info domain.NodeReplicationInf
 
 	if err := s.store.UpdateReplicationInfo(ctx, info); err != nil {
 		return fmt.Errorf("replicate update isAdjusted failed: %v", err)
-	} else {
-		logEntry.Info("isAdjusted success")
 	}
+
+	logEntry.Info("isAdjusted success")
 
 	return nil
 }

--- a/p2p/kademlia/store.go
+++ b/p2p/kademlia/store.go
@@ -2,6 +2,9 @@ package kademlia
 
 import (
 	"context"
+	"time"
+
+	"github.com/pastelnetwork/gonode/p2p/kademlia/domain"
 )
 
 // Store is the interface for implementing the storage mechanism for the DHT
@@ -16,7 +19,7 @@ type Store interface {
 	Delete(ctx context.Context, key []byte)
 
 	// KeysForReplication returns the keys of all data to be replicated across the network
-	GetKeysForReplication(ctx context.Context) [][]byte
+	GetKeysForReplication(ctx context.Context, from time.Time) [][]byte
 
 	// Stats returns stats of store
 	Stats(ctx context.Context) (map[string]interface{}, error)
@@ -32,4 +35,13 @@ type Store interface {
 
 	// UpdateKeyReplication updates the replication status of the key
 	UpdateKeyReplication(ctx context.Context, key []byte) error
+
+	// GetAllReplicationInfo returns all records in replication table
+	GetAllReplicationInfo(_ context.Context) ([]domain.NodeReplicationInfo, error)
+
+	// UpdateReplicationInfo updates replication info
+	UpdateReplicationInfo(_ context.Context, rep domain.NodeReplicationInfo) error
+
+	// AddReplicationInfo adds replication info
+	AddReplicationInfo(_ context.Context, rep domain.NodeReplicationInfo) error
 }

--- a/p2p/kademlia/store/mem/mem.go
+++ b/p2p/kademlia/store/mem/mem.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"sync"
 	"time"
+
+	"github.com/pastelnetwork/gonode/p2p/kademlia/domain"
 )
 
 // Store is a simple in-memory key/value store used for unit testing
@@ -19,7 +21,7 @@ type Store struct {
 // GetKeysForReplication should return the keys of all data to be
 // replicated across the network. Typically all data should be
 // replicated every tReplicate seconds.
-func (s *Store) GetKeysForReplication(_ context.Context) [][]byte {
+func (s *Store) GetKeysForReplication(_ context.Context, _ time.Time) [][]byte {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 
@@ -101,4 +103,19 @@ func NewStore() *Store {
 		replications:      make(map[string]time.Time),
 		replicateInterval: time.Second * 3600,
 	}
+}
+
+// GetAllReplicationInfo returns all records in replication table
+func (s *Store) GetAllReplicationInfo(_ context.Context) ([]domain.NodeReplicationInfo, error) {
+	return nil, nil
+}
+
+// UpdateReplicationInfo updates replication info
+func (s *Store) UpdateReplicationInfo(_ context.Context, _ domain.NodeReplicationInfo) error {
+	return nil
+}
+
+// AddReplicationInfo adds replication info
+func (s *Store) AddReplicationInfo(_ context.Context, _ domain.NodeReplicationInfo) error {
+	return nil
 }

--- a/p2p/kademlia/store/sqlite/sqlite.go
+++ b/p2p/kademlia/store/sqlite/sqlite.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/pastelnetwork/gonode/p2p/kademlia/domain"
+
 	"github.com/pastelnetwork/gonode/common/utils"
 
 	"github.com/pastelnetwork/gonode/common/log"
@@ -75,6 +77,12 @@ func NewStore(ctx context.Context, dataDir string, replicate time.Duration, repu
 		}
 	}
 
+	if !s.checkReplicateStore() {
+		if err = s.migrateReplication(); err != nil {
+			return nil, fmt.Errorf("cannot create table(s) in sqlite database: %w", err)
+		}
+	}
+
 	return s, nil
 }
 
@@ -83,6 +91,16 @@ func (s *Store) checkStore() bool {
 	defer s.rwMtx.RUnlock()
 
 	query := `SELECT name FROM sqlite_master WHERE type='table' AND name='data'`
+	var name string
+	err := s.db.Get(&name, query)
+	return err == nil
+}
+
+func (s *Store) checkReplicateStore() bool {
+	s.rwMtx.RLock()
+	defer s.rwMtx.RUnlock()
+
+	query := `SELECT name FROM sqlite_master WHERE type='table' AND name='replication_info'`
 	var name string
 	err := s.db.Get(&name, query)
 	return err == nil
@@ -104,7 +122,53 @@ func (s *Store) migrate() error {
 	if _, err := s.db.Exec(query); err != nil {
 		return fmt.Errorf("failed to create table 'data': %w", err)
 	}
+
 	return nil
+}
+
+func (s *Store) migrateReplication() error {
+	replicateQuery := `
+    CREATE TABLE IF NOT EXISTS replication_info(
+        id TEXT PRIMARY KEY,
+        ip TEXT NOT NULL,
+		port INTEGER NOT NULL,
+        is_active BOOL DEFAULT FALSE,
+		is_adjusted BOOL DEFAULT FALSE,
+        lastReplicatedAt DATETIME,
+		createdAt DATETIME DEFAULT CURRENT_TIMESTAMP,
+        updatedAt DATETIME DEFAULT CURRENT_TIMESTAMP
+    );
+    `
+
+	if _, err := s.db.Exec(replicateQuery); err != nil {
+		return fmt.Errorf("failed to create table 'replication_info': %w", err)
+	}
+
+	return nil
+}
+
+type nodeReplicationInfo struct {
+	LastReplicated *time.Time `db:"lastReplicatedAt"`
+	UpdatedAt      time.Time  `db:"updatedAt"`
+	CreatedAt      time.Time  `db:"createdAt"`
+	Active         bool       `db:"is_active"`
+	Adjusted       bool       `db:"is_adjusted"`
+	IP             string     `db:"ip"`
+	Port           int        `db:"port"`
+	ID             string     `db:"id"`
+}
+
+func (n *nodeReplicationInfo) toDomain() domain.NodeReplicationInfo {
+	return domain.NodeReplicationInfo{
+		LastReplicatedAt: n.LastReplicated,
+		UpdatedAt:        n.UpdatedAt,
+		CreatedAt:        n.CreatedAt,
+		Active:           n.Active,
+		IsAdjusted:       n.Adjusted,
+		IP:               n.IP,
+		Port:             n.Port,
+		ID:               []byte(n.ID),
+	}
 }
 
 // Store will store a key/value pair for the local node
@@ -189,16 +253,13 @@ func (s *Store) UpdateKeyReplication(_ context.Context, key []byte) error {
 // GetKeysForReplication should return the keys of all data to be
 // replicated across the network. Typically all data should be
 // replicated every tReplicate seconds.
-func (s *Store) GetKeysForReplication(ctx context.Context) [][]byte {
+func (s *Store) GetKeysForReplication(ctx context.Context, from time.Time) [][]byte {
 	s.rwMtx.RLock()
 	defer s.rwMtx.RUnlock()
 
-	now := time.Now().UTC()
-	after := now.Add(-s.replicateInterval).UTC()
-
 	var keys [][]byte
-	if err := s.db.Select(&keys, `SELECT key FROM data WHERE updatedAt > ? and replicatedAt is NULL`, after); err != nil {
-		log.P2P().WithContext(ctx).Errorf("failed to get records for replication older than %s: %v", after, err)
+	if err := s.db.Select(&keys, `SELECT key FROM data WHERE createdAt > ?`, from); err != nil {
+		log.P2P().WithError(err).WithContext(ctx).Errorf("failed to get records for replication older than %s", from)
 		return nil
 	}
 	log.P2P().WithContext(ctx).WithField("keyslength", len(keys)).Debugf("Replication keys found: %+v", keys)
@@ -276,4 +337,42 @@ func (s *Store) DeleteAll(_ context.Context /*, type RecordType*/) error {
 		return fmt.Errorf("failed to delete ALL records")
 	}
 	return nil
+}
+
+// GetAllReplicationInfo returns all records in replication table
+func (s *Store) GetAllReplicationInfo(_ context.Context) ([]domain.NodeReplicationInfo, error) {
+	r := []nodeReplicationInfo{}
+	err := s.db.Select(&r, "SELECT * FROM replication_info")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get replication info %w", err)
+	}
+
+	list := []domain.NodeReplicationInfo{}
+	for _, v := range r {
+		list = append(list, v.toDomain())
+	}
+
+	return list, nil
+}
+
+// UpdateReplicationInfo updates replication info
+func (s *Store) UpdateReplicationInfo(_ context.Context, rep domain.NodeReplicationInfo) error {
+	_, err := s.db.Exec(`UPDATE replication_info SET ip = ?, is_active = ?, is_adjusted = ?, lastReplicatedAt = ?, updatedAt =?, port = ? WHERE id = ?`,
+		rep.IP, rep.Active, rep.IsAdjusted, rep.LastReplicatedAt, rep.UpdatedAt, rep.Port, string(rep.ID))
+	if err != nil {
+		return fmt.Errorf("failed to update replicated records: %v", err)
+	}
+
+	return err
+}
+
+// AddReplicationInfo adds replication info
+func (s *Store) AddReplicationInfo(_ context.Context, rep domain.NodeReplicationInfo) error {
+	_, err := s.db.Exec(`INSERT INTO replication_info(id, ip, is_active, is_adjusted, lastReplicatedAt, updatedAt, port) values(?, ?, ?, ?, ?, ?, ?)`,
+		string(rep.ID), rep.IP, rep.Active, rep.IsAdjusted, rep.LastReplicatedAt, rep.UpdatedAt, rep.Port)
+	if err != nil {
+		return fmt.Errorf("failed to update replicate record: %v", err)
+	}
+
+	return err
 }


### PR DESCRIPTION
summary of changes:
1- Add new table in database to support keeping record of nodes replication info.
2- Add a replication worker and initiate it with kademlia
3- It will load up replication records from database.
4-  As soon as a new node joins (or old one joins back), we add it in the list and update the record in database to mark the "last seen" time
5- Now a node will keep this info about  replication regarding every node that was ever seen in the network.
type nodeReplicationInfo struct {
	LastReplicated *time.Time `db:"lastReplicatedAt"`
	UpdatedAt      time.Time  `db:"updated_at"`
	CreatedAt      time.Time  `db:"created_at"`
	Active         bool       `db:"active"`
	IP             string     `db:"ip"`
	Port           int        `db:"port"`
	ID             string     `db:"id"`
}
6- After every few minutes, it will loop through the active nodes and checks if its last_replicated_at timestamp is suggestive that data should be replicated again. In that case;
 it will take all the keys that were added b/w that timeline and check which of the keys is supposed to be stored by that node and than ONLY send request to that node to store the data [This is very important newly added functionality].
in case of successful store, we update last replicated time for that node.
7- Code changes also include a periodic node active check which periodically checks for active (or inactive) nodes in the network and marks them as such and updates database.