### PR TITLE
[PSL-906] batch get p2p

### DIFF
--- a/p2p/kademlia/bootstrap.go
+++ b/p2p/kademlia/bootstrap.go
@@ -212,7 +212,7 @@ func (s *DHT) Bootstrap(ctx context.Context, bootstrapIPs string) error {
 				// add the node to the route table
 				log.P2P().WithContext(ctx).WithField("sender-id", string(response.Sender.ID)).
 					WithField("sender-ip", string(response.Sender.IP)).
-					WithField("sender-port", response.Sender.Port).Info("add-node params")
+					WithField("sender-port", response.Sender.Port).Debug("add-node params")
 
 				if len(response.Sender.ID) != len(s.ht.self.ID) {
 					log.P2P().WithContext(ctx).WithField("sender-id", string(response.Sender.ID)).

--- a/p2p/kademlia/common.go
+++ b/p2p/kademlia/common.go
@@ -1,0 +1,100 @@
+package kademlia
+
+import (
+	"bytes"
+	"encoding/gob"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/DataDog/zstd"
+)
+
+func compressKeys(keys [][]byte) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := gob.NewEncoder(&buf)
+
+	if err := enc.Encode(keys); err != nil {
+		return nil, fmt.Errorf("encode error: %w", err)
+	}
+
+	compressed, err := zstd.CompressLevel(nil, buf.Bytes(), 22)
+	if err != nil {
+		return nil, fmt.Errorf("compression error: %w", err)
+	}
+
+	return compressed, nil
+}
+
+func decompressKeys(data []byte) ([][]byte, error) {
+	decompressed, err := zstd.Decompress(nil, data)
+	if err != nil {
+		return nil, fmt.Errorf("decompression error: %w", err)
+	}
+
+	dec := gob.NewDecoder(bytes.NewReader(decompressed))
+
+	var keys [][]byte
+	if err := dec.Decode(&keys); err != nil {
+		return nil, fmt.Errorf("decode error: %w", err)
+	}
+
+	return keys, nil
+}
+
+// Function to generate a key from a node object.
+func generateKeyFromNode(node *Node) string {
+	return string(node.ID) + ":" + node.IP + ":" + fmt.Sprint(node.Port)
+}
+
+// Function to retrieve a node object from a key.
+func getNodeFromKey(key string) (*Node, error) {
+	parts := strings.Split(key, ":")
+
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("invalid key")
+	}
+
+	id := []byte(parts[0])
+	ip := parts[1]
+
+	// strconv.Atoi returns an int and an error, which we need to handle.
+	port, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return nil, fmt.Errorf("invalid port: %w", err)
+	}
+
+	return &Node{ID: id, IP: ip, Port: port}, nil
+}
+
+func compressKeysStr(keys []string) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := gob.NewEncoder(&buf)
+
+	if err := enc.Encode(keys); err != nil {
+		return nil, fmt.Errorf("encode error: %w", err)
+	}
+
+	compressed, err := zstd.CompressLevel(nil, buf.Bytes(), 22)
+	if err != nil {
+		return nil, fmt.Errorf("compression error: %w", err)
+	}
+
+	return compressed, nil
+}
+
+func decompressKeysStr(data []byte) ([]string, error) {
+	decompressed, err := zstd.Decompress(nil, data)
+	if err != nil {
+		return nil, fmt.Errorf("decompression error: %w", err)
+	}
+
+	dec := gob.NewDecoder(bytes.NewReader(decompressed))
+
+	var keys []string
+	if err := dec.Decode(&keys); err != nil {
+		return nil, fmt.Errorf("decode error: %w", err)
+	}
+
+	return keys, nil
+}

--- a/p2p/kademlia/domain/domain.go
+++ b/p2p/kademlia/domain/domain.go
@@ -25,4 +25,5 @@ type ToRepKey struct {
 	IP        string    `json:"ip"`
 	Port      int       `json:"port"`
 	ID        string    `json:"id"`
+	Attempts  int       `json:"attempts"`
 }

--- a/p2p/kademlia/fetch_and_store.go
+++ b/p2p/kademlia/fetch_and_store.go
@@ -1,0 +1,345 @@
+package kademlia
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"github.com/DataDog/zstd"
+	"github.com/cenkalti/backoff"
+	"github.com/pastelnetwork/gonode/common/log"
+	"github.com/pastelnetwork/gonode/common/utils"
+	"github.com/pastelnetwork/gonode/p2p/kademlia/domain"
+)
+
+const (
+	maxBatchAttempts                     = 1
+	oneMB                                = 1024 * 1024 // 1 MB in bytes
+	totalMaxAttempts                     = 20
+	maxSingleBatchIterations             = 10
+	failedKeysClosestContactsLookupCount = 12
+	fetchBatchSize                       = 600
+)
+
+// FetchAndStore fetches all keys from the local TODO replicate list, fetches value from respective nodes and stores them in the local store
+func (s *DHT) FetchAndStore(ctx context.Context) error {
+	log.WithContext(ctx).Info("Getting fetch and store keys")
+	keys, err := s.store.GetAllToDoRepKeys(failedKeysClosestContactsLookupCount+maxBatchAttempts+1, totalMaxAttempts)
+	if err != nil {
+		return fmt.Errorf("get all keys error: %w", err)
+	}
+	log.WithContext(ctx).WithField("count", len(keys)).Info("got keys from local store")
+
+	if len(keys) == 0 {
+		return nil
+	}
+
+	//wg := sync.WaitGroup{}
+	//wg.Add(len(keys))        // Add count of all keys before spawning goroutines
+	var successCounter int32 // Create a counter for successful operations
+
+	for i := 0; i < len(keys); i++ {
+		key := keys[i]
+
+		func(info domain.ToRepKey) {
+			//defer wg.Done()
+			cctx, ccancel := context.WithTimeout(ctx, 30*time.Second)
+			defer ccancel()
+
+			sKey := hex.EncodeToString(info.Key)
+			n := Node{ID: []byte(info.ID), IP: info.IP, Port: info.Port}
+
+			b := backoff.WithMaxRetries(backoff.NewConstantBackOff(2*time.Second), 10)
+			var value []byte // replace with the actual type of "value"
+			err := backoff.Retry(func() error {
+				val, err := s.GetValueFromNode(cctx, info.Key, &n)
+				if err != nil {
+					return err
+				}
+				value = val
+				return nil
+			}, b)
+
+			if err != nil {
+				log.WithContext(cctx).WithField("key", sKey).WithField("ip", info.IP).WithError(err).Error("fetch & store key failed")
+				value, err = s.iterateFindValue(cctx, IterateFindValue, info.Key)
+				if err != nil {
+					log.WithContext(cctx).WithField("key", sKey).WithField("ip", info.IP).WithError(err).Error("iterate fetch for replication failed")
+					return
+				} else if len(value) == 0 {
+					log.WithContext(cctx).WithField("key", sKey).WithField("ip", info.IP).WithError(err).Error("iterate fetch for replication failed 0 val")
+					return
+				} else {
+					log.WithContext(cctx).WithField("key", sKey).WithField("ip", info.IP).Info("iterate fetch for replication success")
+				}
+			}
+
+			if err := s.store.Store(cctx, info.Key, value, 0, false); err != nil {
+				log.WithContext(cctx).WithField("key", sKey).WithField("ip", info.IP).WithError(err).Error("fetch & local store key failed")
+				return
+			}
+
+			if err := s.store.DeleteRepKey(info.Key); err != nil {
+				log.WithContext(cctx).WithField("key", sKey).WithField("ip", info.IP).WithError(err).Error("delete key from todo list failed")
+				return
+			}
+
+			atomic.AddInt32(&successCounter, 1) // Increment the counter atomically
+
+			log.WithContext(cctx).WithField("key", sKey).WithField("ip", info.IP).Info("fetch & store key success")
+		}(key)
+
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	//wg.Wait()
+
+	log.WithContext(ctx).WithField("todo-keys", len(keys)).WithField("successfully-added-keys", atomic.LoadInt32(&successCounter)).Infof("Successfully fetched & stored keys") // Log the final count
+
+	return nil
+}
+
+// BatchFetchAndStoreFailedKeys fetches all failed keys from the local TODO replicate list, fetches value from respective nodes and stores them in the local store
+func (s *DHT) BatchFetchAndStoreFailedKeys(ctx context.Context) error {
+	log.WithContext(ctx).Info("Getting batch fetch and store keys")
+	keys, err := s.store.GetAllToDoRepKeys(maxBatchAttempts+1, failedKeysClosestContactsLookupCount+maxBatchAttempts+1) // 2 - 14
+	if err != nil {
+		return fmt.Errorf("get all keys error: %w", err)
+	}
+	log.WithContext(ctx).WithField("count", len(keys)).Info("read failed keys from store")
+
+	if len(keys) == 0 {
+		return nil
+	}
+
+	repKeys := make([]domain.ToRepKey, 0, len(keys))
+	for i := 0; i < len(keys); i++ {
+		igList := s.ignorelist.ToNodeList()
+		nl := s.ht.closestContacts(failedKeysClosestContactsLookupCount, keys[i].Key, igList)
+		attempt := (keys[i].Attempts - maxBatchAttempts) + 1
+
+		if len(nl.Nodes) > attempt {
+			repKey := domain.ToRepKey{
+				Key:  keys[i].Key,
+				ID:   string(nl.Nodes[attempt].ID),
+				IP:   nl.Nodes[attempt].IP,
+				Port: nl.Nodes[attempt].Port,
+			}
+
+			repKeys = append(repKeys, repKey)
+		}
+	}
+	log.WithField("count", len(repKeys)).Info("got to-fetch failed todo rep-keys from store")
+
+	if err := s.GroupAndBatchFetch(ctx, repKeys, 0, false); err != nil {
+		log.WithContext(ctx).WithError(err).Error("group and batch fetch failed-keys error")
+		return fmt.Errorf("group and batch fetch failed keys error: %w", err)
+	}
+
+	return nil
+}
+
+// BatchFetchAndStore fetches all keys from the local TODO replicate list, fetches value from respective nodes and stores them in the local store
+func (s *DHT) BatchFetchAndStore(ctx context.Context) error {
+	log.WithContext(ctx).Info("Getting batch fetch and store keys")
+	keys, err := s.store.GetAllToDoRepKeys(0, maxBatchAttempts)
+	if err != nil {
+		return fmt.Errorf("get all keys error: %w", err)
+	}
+	log.WithContext(ctx).WithField("count", len(keys)).Info("got batch todo rep-keys from local store")
+
+	if len(keys) == 0 {
+		return nil
+	}
+
+	if err := s.GroupAndBatchFetch(ctx, keys, 0, false); err != nil {
+		log.WithContext(ctx).WithError(err).Error("group and batch fetch error")
+		return fmt.Errorf("group and batch fetch error: %w", err)
+	}
+
+	return nil
+}
+
+// GroupAndBatchFetch gets values from nodes in batches and store them
+func (s *DHT) GroupAndBatchFetch(ctx context.Context, repKeys []domain.ToRepKey, datatype int, isOriginal bool) error {
+	nodeMap := make(map[string][]*domain.ToRepKey)
+
+	// Group keys by Node
+	for i := 0; i < len(repKeys); i++ {
+		node := &Node{
+			ID:   []byte(repKeys[i].ID),
+			IP:   repKeys[i].IP,
+			Port: repKeys[i].Port,
+		}
+		nodeKey := generateKeyFromNode(node)
+		nodeMap[nodeKey] = append(nodeMap[nodeKey], &repKeys[i])
+	}
+
+	// Fetch from each Node and store directly
+	for nodeKey, repKeyList := range nodeMap {
+		node, err := getNodeFromKey(nodeKey)
+		if err != nil {
+			return fmt.Errorf("invalid nodeKey %s: %w", nodeKey, err)
+		}
+
+		// Fetch from node in batches
+		for i := 0; i < len(repKeyList); i += fetchBatchSize {
+			end := i + fetchBatchSize
+			if end > len(repKeyList) {
+				end = len(repKeyList)
+			}
+
+			// Convert repKeyList[i:end] to byteKeys
+			stringKeys := make([]string, end-i)
+			for j, key := range repKeyList[i:end] {
+				stringKeys[j] = hex.EncodeToString(key.Key)
+			}
+
+			iterations := 0
+			totalKeysFound := 0
+			for len(stringKeys) > 0 && iterations < maxSingleBatchIterations {
+				iterations++
+				log.WithContext(ctx).WithField("node-ip", node.IP).WithField("count", len(stringKeys)).WithField("keys[0]", stringKeys[0]).
+					WithField("keys[len()]", stringKeys[len(stringKeys)-1]).Info("fetching batch values from node")
+
+				isDone, retMap, failedKeys, err := s.GetBatchValuesFromNode(ctx, stringKeys, node)
+				if err != nil {
+					// Log the error but don't stop the process, continue to the next node
+					log.WithContext(ctx).WithField("node-ip", node.IP).WithError(err).Info("failed to get batch values")
+					continue
+				}
+
+				// Convert retMap to response
+				stringDelKeys := make([]string, 0)
+				var response [][]byte
+				for key, value := range retMap {
+					if len(value) > 0 {
+						stringDelKeys = append(stringDelKeys, key)
+						response = append(response, value)
+						totalKeysFound++
+					}
+				}
+
+				if len(stringDelKeys) > 0 {
+					// Store the values directly
+					err = s.store.StoreBatch(ctx, response, datatype, isOriginal)
+					if err != nil {
+						// Log the error but don't stop the process, continue to the next node
+						log.WithContext(ctx).WithField("node-ip", node.IP).WithError(err).Info("failed to store batch values")
+						continue
+					}
+
+					// Delete the keys that were successfully stored
+					err = s.store.BatchDeleteRepKeys(stringDelKeys)
+					if err != nil {
+						// Log the error but don't stop the process, continue to the next node
+						log.WithContext(ctx).WithField("node-ip", node.IP).WithError(err).Info("failed to delete rep keys")
+						continue
+					}
+				} else {
+					log.WithContext(ctx).WithField("node-ip", node.IP).Warn("no values found in batch fetch")
+				}
+
+				if isDone && len(failedKeys) > 0 {
+					if err := s.store.IncrementAttempts(failedKeys); err != nil {
+						log.WithContext(ctx).WithField("node-ip", node.IP).WithError(err).Info("failed to increment attempts")
+						// not adding 'continue' here because we want to delete the keys from the todo list
+					}
+				} else if isDone {
+					stringKeys = []string{}
+				} else if !isDone {
+					stringKeys = failedKeys
+				}
+			}
+
+			log.WithContext(ctx).WithField("node-ip", node.IP).WithField("count", totalKeysFound).WithField("iterations", iterations).Info("fetch batch values from node successfully")
+		}
+	}
+
+	return nil
+}
+
+// GetBatchValuesFromNode get values from node in bateches
+func (s *DHT) GetBatchValuesFromNode(ctx context.Context, keys []string, n *Node) (bool, map[string][]byte, []string, error) {
+	log.WithContext(ctx).WithField("node-ip", n.IP).WithField("keys", len(keys)).Info("sending batch fetch request")
+
+	messageType := BatchFindValues
+	compKeys, err := compressKeysStr(keys)
+	if err != nil {
+		return false, nil, nil, fmt.Errorf("compress keys error: %w", err)
+	}
+
+	data := &BatchFindValuesRequest{Keys: compKeys}
+	request := s.newMessage(messageType, n, data)
+
+	response, err := s.network.Call(ctx, request, true)
+	if err != nil {
+		log.P2P().WithContext(ctx).WithError(err).Errorf("network call request %s failed", request.String())
+		return false, nil, nil, fmt.Errorf("network call request %s failed: %w", request.String(), err)
+	}
+
+	v, ok := response.Data.(*BatchFindValuesResponse)
+	isDone := false
+	if ok && v.Status.Result == ResultOk {
+		// First, decompress the data
+		decompressedData, err := zstd.Decompress(nil, v.Response)
+		if err != nil {
+			return isDone, nil, nil, fmt.Errorf("failed to decompress data: %w", err)
+		}
+
+		// Next, unmarshal the decompressed data back into a map
+		var decompressedMap map[string][]byte
+		err = json.Unmarshal(decompressedData, &decompressedMap)
+		if err != nil {
+			return isDone, nil, nil, fmt.Errorf("failed to unmarshal data: %w", err)
+		}
+
+		retMap, failedKeys, err := VerifyAndFilter(decompressedMap)
+		if err != nil {
+			return isDone, nil, nil, fmt.Errorf("failed to verify and filter data: %w", err)
+		}
+		log.WithContext(ctx).WithField("node-ip", n.IP).WithField("received-keys", len(decompressedMap)).
+			WithField("verified-keys", len(retMap)).WithField("failed-keys", len(failedKeys)).Info("batch fetch response rcvd and keys verified")
+
+		return v.Done, retMap, failedKeys, nil
+	}
+
+	return false, nil, nil, fmt.Errorf("batch get request failure - %s - node: %s", response.String(), n.String())
+}
+
+// VerifyAndFilter verifies the data and filters out the failed keys
+func VerifyAndFilter(decompressedMap map[string][]byte) (map[string][]byte, []string, error) {
+	var retMap = make(map[string][]byte)
+	var failedKeys []string
+
+	for key, value := range decompressedMap {
+		if len(value) == 0 {
+			failedKeys = append(failedKeys, key)
+			continue
+		}
+
+		// Compute the SHA256 hash of the value using the helper function
+		hash, err := utils.Sha3256hash(value)
+		if err != nil {
+			failedKeys = append(failedKeys, key)
+			log.WithError(err).Error("failed to compute hash")
+			continue
+		}
+
+		// Encode the hash to a hex string
+		hashHex := hex.EncodeToString(hash)
+
+		// Compare the computed hash with the key
+		if hashHex == key {
+			retMap[key] = value
+		} else {
+			log.WithField("key", key).WithField("hash", hashHex).Error("hash mismatch")
+			failedKeys = append(failedKeys, key)
+		}
+	}
+
+	return retMap, failedKeys, nil
+}

--- a/p2p/kademlia/message.go
+++ b/p2p/kademlia/message.go
@@ -21,6 +21,8 @@ const (
 	FindValue
 	// Replicate is replicate data request towards a network node
 	Replicate
+	// BatchFindValues finds values in kademlia network
+	BatchFindValues
 )
 
 func init() {
@@ -33,6 +35,8 @@ func init() {
 	gob.Register(&StoreDataResponse{})
 	gob.Register(&ReplicateDataRequest{})
 	gob.Register(&ReplicateDataResponse{})
+	gob.Register(&BatchFindValuesRequest{})
+	gob.Register(&BatchFindValuesResponse{})
 }
 
 // Message structure for kademlia network
@@ -105,6 +109,18 @@ type StoreDataRequest struct {
 // StoreDataResponse defines the response data for store data
 type StoreDataResponse struct {
 	Status ResponseStatus
+}
+
+// BatchFindValuesRequest defines the request data for find value
+type BatchFindValuesRequest struct {
+	Keys []byte
+}
+
+// BatchFindValuesResponse defines the response data for find value
+type BatchFindValuesResponse struct {
+	Status   ResponseStatus
+	Response []byte
+	Done     bool
 }
 
 // encode the message

--- a/p2p/kademlia/message_test.go
+++ b/p2p/kademlia/message_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestMessagePayloadTooBig(t *testing.T) {
 	// generate message
-	data := make([]byte, 32*1024*1024+1)
+	data := make([]byte, 100*1024*1024+1)
 	rand.Read(data)
 	msg := &Message{
 		Sender:      nil,

--- a/p2p/kademlia/node.go
+++ b/p2p/kademlia/node.go
@@ -161,3 +161,21 @@ func (s *NodeList) Sort() {
 		return distances[i].Cmp(&distances[j]) == -1
 	})
 }
+
+// Swap swap two nodes
+func (s *NodeList) Swap(i, j int) {
+	if i >= 0 && i < s.Len() && j >= 0 && j < s.Len() {
+		s.Nodes[i], s.Nodes[j] = s.Nodes[j], s.Nodes[i]
+	}
+}
+
+// Less compare two nodes
+func (s *NodeList) Less(i, j int) bool {
+	if i >= 0 && i < s.Len() && j >= 0 && j < s.Len() {
+		id := s.distance(s.Nodes[i].ID, s.Comparator)
+		jd := s.distance(s.Nodes[j].ID, s.Comparator)
+
+		return id.Cmp(jd) == -1
+	}
+	return false
+}

--- a/p2p/kademlia/node_activity.go
+++ b/p2p/kademlia/node_activity.go
@@ -1,0 +1,100 @@
+package kademlia
+
+import (
+	"context"
+	"time"
+
+	"github.com/pastelnetwork/gonode/common/log"
+	"github.com/pastelnetwork/gonode/common/utils"
+)
+
+// checkNodeActivity keeps track of active nodes - the idea here is to ping nodes periodically and mark them as inactive if they don't respond
+func (s *DHT) checkNodeActivity(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(checkNodeActivityInterval): // Adjust the interval as needed
+			func() {
+				if !utils.CheckInternetConnectivity() {
+					log.WithContext(ctx).Info("no internet connectivity, not checking node activity")
+				} else {
+					nrt := s.getNodeReplicationTimesCopy()
+
+					for nodeID, info := range nrt {
+						// new a ping request message
+						node := &Node{
+							ID:   []byte(nodeID),
+							IP:   info.IP,
+							Port: info.Port,
+						}
+
+						request := s.newMessage(Ping, node, nil)
+						// new a context with timeout
+						ctx, cancel := context.WithTimeout(ctx, defaultPingTime)
+						defer cancel()
+
+						// invoke the request and handle the response
+						_, err := s.network.Call(ctx, request, false)
+						if err != nil && info.Active {
+							log.P2P().WithContext(ctx).WithError(err).WithField("ip", info.IP).WithField("node_id", string(nodeID)).
+								Error("failed to ping node, setting node to inactive")
+
+							// add node to ignore list
+							// we maintain this list to avoid pinging nodes that are not responding
+							s.ignorelist.IncrementCount(node)
+
+							// mark node as inactive in database
+							info.Active = false
+							info.UpdatedAt = time.Now()
+
+							s.replicationMtx.Lock()
+							s.nodeReplicationTimes[string(nodeID)] = info
+							s.replicationMtx.Unlock()
+
+							if err := s.store.UpdateReplicationInfo(ctx, info); err != nil {
+								log.P2P().WithContext(ctx).WithError(err).WithField("ip", info.IP).WithField("node_id", string(nodeID)).Error("failed to update replication info, node is inactive")
+							}
+
+						} else if err == nil {
+							if !info.Active {
+								log.P2P().WithContext(ctx).WithField("ip", info.IP).WithField("node_id", string(nodeID)).Info("node found to be active again")
+
+								// remove node from ignore list
+								s.ignorelist.Delete(node)
+
+								// mark node as active in database
+								info.Active = true
+								info.IsAdjusted = false
+								info.UpdatedAt = time.Now()
+
+								s.replicationMtx.Lock()
+								s.nodeReplicationTimes[string(nodeID)] = info
+								s.replicationMtx.Unlock()
+
+								if err := s.store.UpdateReplicationInfo(ctx, info); err != nil {
+									log.P2P().WithContext(ctx).WithError(err).WithField("ip", info.IP).WithField("node_id", string(nodeID)).Error("failed to update replication info, node is active")
+								}
+							}
+
+							s.replicationMtx.RLock()
+							upInfo := s.nodeReplicationTimes[string(nodeID)]
+							s.replicationMtx.RUnlock()
+
+							now := time.Now()
+							upInfo.LastSeen = &now
+
+							s.replicationMtx.Lock()
+							s.nodeReplicationTimes[string(nodeID)] = upInfo
+							s.replicationMtx.Unlock()
+
+							if err := s.store.UpdateLastSeen(ctx, string(nodeID)); err != nil {
+								log.WithContext(ctx).WithError(err).WithField("ip", info.IP).WithField("node_id", string(nodeID)).Error("failed to update last seen")
+							}
+						}
+					}
+				}
+			}()
+		}
+	}
+}

--- a/p2p/kademlia/replication.go
+++ b/p2p/kademlia/replication.go
@@ -78,7 +78,7 @@ func (s *DHT) StartBatchFetchAndStoreWorker(ctx context.Context) error {
 	}
 }
 
-// StartFetchAndStoreWorker starts replication
+// StartFailedFetchAndStoreWorker starts replication
 func (s *DHT) StartFailedFetchAndStoreWorker(ctx context.Context) error {
 	log.P2P().WithContext(ctx).Info("fetch and store worker started")
 
@@ -253,6 +253,8 @@ func (s *DHT) Replicate(ctx context.Context) {
 			} else {
 				logEntry.WithField("node", info.IP).WithField("to", to.String()).WithField("closest-contact-keys", 0).Info("replicate update lastReplicated success")
 			}
+
+			continue
 		}
 
 		data, err := compressKeys(closestContactKeys)

--- a/p2p/kademlia/replication.go
+++ b/p2p/kademlia/replication.go
@@ -4,34 +4,30 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"strconv"
-	"strings"
-	"sync/atomic"
 	"time"
 
-	"encoding/gob"
 	"encoding/hex"
 
-	"github.com/DataDog/zstd"
 	"github.com/cenkalti/backoff"
 	"github.com/pastelnetwork/gonode/common/errors"
 	"github.com/pastelnetwork/gonode/common/log"
-	"github.com/pastelnetwork/gonode/common/utils"
 	"github.com/pastelnetwork/gonode/p2p/kademlia/domain"
 )
 
 var (
 	// defaultReplicationInterval is the default interval for replication.
-	defaultReplicationInterval = time.Minute * 15
+	defaultReplicationInterval = time.Minute * 10
 
 	// nodeShowUpDeadline is the time after which the node will considered to be permeant offline
 	// we'll adjust the keys once the node is permeant offline
 	nodeShowUpDeadline = time.Minute * 35
 
 	// check for active & inactive nodes after this interval
-	checkNodeActivityInterval = time.Minute * 3
+	checkNodeActivityInterval = time.Minute * 2
 
-	defaultFetchAndStoreInterval = time.Minute * 5
+	defaultFetchAndStoreInterval = time.Minute * 10
+
+	defaultBatchFetchAndStoreInterval = time.Minute * 5
 
 	maxBackOff = 45 * time.Second
 )
@@ -53,7 +49,8 @@ func (s *DHT) StartReplicationWorker(ctx context.Context) error {
 	log.P2P().WithContext(ctx).Info("replication worker started")
 
 	go s.checkNodeActivity(ctx)
-	go s.StartFetchAndStoreWorker(ctx)
+	go s.StartBatchFetchAndStoreWorker(ctx)
+	go s.StartFailedFetchAndStoreWorker(ctx)
 
 	for {
 		select {
@@ -66,14 +63,29 @@ func (s *DHT) StartReplicationWorker(ctx context.Context) error {
 	}
 }
 
+// StartBatchFetchAndStoreWorker starts replication
+func (s *DHT) StartBatchFetchAndStoreWorker(ctx context.Context) error {
+	log.P2P().WithContext(ctx).Info("batch fetch and store worker started")
+
+	for {
+		select {
+		case <-time.After(defaultBatchFetchAndStoreInterval):
+			s.BatchFetchAndStore(ctx)
+		case <-ctx.Done():
+			log.P2P().WithContext(ctx).Error("closing batch fetch & store worker")
+			return nil
+		}
+	}
+}
+
 // StartFetchAndStoreWorker starts replication
-func (s *DHT) StartFetchAndStoreWorker(ctx context.Context) error {
+func (s *DHT) StartFailedFetchAndStoreWorker(ctx context.Context) error {
 	log.P2P().WithContext(ctx).Info("fetch and store worker started")
 
 	for {
 		select {
 		case <-time.After(defaultFetchAndStoreInterval):
-			s.FetchAndStore(ctx)
+			s.BatchFetchAndStoreFailedKeys(ctx)
 		case <-ctx.Done():
 			log.P2P().WithContext(ctx).Error("closing fetch & store worker")
 			return nil
@@ -154,7 +166,7 @@ func (s *DHT) Replicate(ctx context.Context) {
 		historicStart = time.Now().Add(-24 * time.Hour * 180)
 	}
 
-	log.P2P().WithContext(ctx).Info("replicating data")
+	log.P2P().WithContext(ctx).WithField("historic-start", historicStart).Info("replicating data")
 
 	for i := 0; i < B; i++ {
 		if time.Since(s.ht.refreshTime(i)) > defaultRefreshTime {
@@ -206,24 +218,26 @@ func (s *DHT) Replicate(ctx context.Context) {
 
 		logEntry.WithField("from", from).WithField("to", to).Info("getting replication keys")
 		replicationKeys := s.store.GetKeysForReplication(ctx, from, to)
-		logEntry.WithField("len-rep-keys", len(replicationKeys)).Info("count of replication keys to be checked")
+
 		if len(replicationKeys) == 0 {
 			// Now closestContactKeys contains all the keys that are in the closest contacts.
 			if err := s.updateLastReplicated(ctx, []byte(nodeID), to); err != nil {
 				logEntry.Error("replicate update lastReplicated failed")
 			} else {
-				logEntry.WithField("node", info.IP).WithField("to", to.String()).WithField("fetch-keys", 0).Info("replicate update lastReplicated success")
+				logEntry.WithField("node", info.IP).WithField("to", to.String()).WithField("fetch-keys", 0).Debug("replicate update lastReplicated success")
 			}
 
 			continue
 		}
 
+		logEntry.WithField("len-rep-keys", len(replicationKeys)).Info("count of replication keys to be checked")
 		// Preallocate a slice with a capacity equal to the number of keys.
 		closestContactKeys := make([][]byte, 0, len(replicationKeys))
 		for i := 0; i < len(replicationKeys); i++ {
 			key := replicationKeys[i]
 			ignores := s.ignorelist.ToNodeList()
-			n := &Node{ID: []byte(nodeID), IP: info.IP, Port: info.Port}
+			n := &Node{ID: []byte(info.ID), IP: info.IP, Port: info.Port}
+
 			nodeList := s.ht.closestContactsWithInlcudingNode(Alpha, key, ignores, n)
 
 			if nodeList.Exists(n) {
@@ -428,231 +442,4 @@ func isNodeGoneAndShouldBeAdjusted(lastSeen *time.Time, isAlreadyAdjusted bool) 
 	}
 
 	return time.Since(*lastSeen) > nodeShowUpDeadline && !isAlreadyAdjusted
-}
-
-// checkNodeActivity keeps track of active nodes - the idea here is to ping nodes periodically and mark them as inactive if they don't respond
-func (s *DHT) checkNodeActivity(ctx context.Context) {
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-time.After(checkNodeActivityInterval): // Adjust the interval as needed
-			func() {
-				if !utils.CheckInternetConnectivity() {
-					log.WithContext(ctx).Info("no internet connectivity, not checking node activity")
-				} else {
-					nrt := s.getNodeReplicationTimesCopy()
-
-					for nodeID, info := range nrt {
-						// new a ping request message
-						node := &Node{
-							ID:   []byte(nodeID),
-							IP:   info.IP,
-							Port: info.Port,
-						}
-
-						request := s.newMessage(Ping, node, nil)
-						// new a context with timeout
-						ctx, cancel := context.WithTimeout(ctx, defaultPingTime)
-						defer cancel()
-
-						// invoke the request and handle the response
-						_, err := s.network.Call(ctx, request, false)
-						if err != nil && info.Active {
-							log.P2P().WithContext(ctx).WithError(err).WithField("ip", info.IP).WithField("node_id", string(nodeID)).
-								Error("failed to ping node, setting node to inactive")
-
-							// add node to ignore list
-							// we maintain this list to avoid pinging nodes that are not responding
-							s.ignorelist.IncrementCount(node)
-
-							// mark node as inactive in database
-							info.Active = false
-							info.UpdatedAt = time.Now()
-
-							s.replicationMtx.Lock()
-							s.nodeReplicationTimes[string(nodeID)] = info
-							s.replicationMtx.Unlock()
-
-							if err := s.store.UpdateReplicationInfo(ctx, info); err != nil {
-								log.P2P().WithContext(ctx).WithError(err).WithField("ip", info.IP).WithField("node_id", string(nodeID)).Error("failed to update replication info, node is inactive")
-							}
-
-						} else if err == nil {
-							log.P2P().WithContext(ctx).WithField("ip", info.IP).WithField("node_id", string(nodeID)).Info("node is active")
-
-							if !info.Active {
-								log.P2P().WithContext(ctx).WithField("ip", info.IP).WithField("node_id", string(nodeID)).Info("node found to be active again")
-
-								// remove node from ignore list
-								s.ignorelist.Delete(node)
-
-								// mark node as active in database
-								info.Active = true
-								info.IsAdjusted = false
-								info.UpdatedAt = time.Now()
-
-								s.replicationMtx.Lock()
-								s.nodeReplicationTimes[string(nodeID)] = info
-								s.replicationMtx.Unlock()
-
-								if err := s.store.UpdateReplicationInfo(ctx, info); err != nil {
-									log.P2P().WithContext(ctx).WithError(err).WithField("ip", info.IP).WithField("node_id", string(nodeID)).Error("failed to update replication info, node is active")
-								}
-							}
-
-							s.replicationMtx.RLock()
-							upInfo := s.nodeReplicationTimes[string(nodeID)]
-							s.replicationMtx.RUnlock()
-
-							now := time.Now()
-							upInfo.LastSeen = &now
-
-							s.replicationMtx.Lock()
-							s.nodeReplicationTimes[string(nodeID)] = upInfo
-							s.replicationMtx.Unlock()
-
-							if err := s.store.UpdateLastSeen(ctx, string(nodeID)); err != nil {
-								log.WithContext(ctx).WithError(err).WithField("ip", info.IP).WithField("node_id", string(nodeID)).Error("failed to update last seen")
-							}
-						}
-					}
-				}
-			}()
-		}
-	}
-}
-
-func compressKeys(keys [][]byte) ([]byte, error) {
-	var buf bytes.Buffer
-	enc := gob.NewEncoder(&buf)
-
-	if err := enc.Encode(keys); err != nil {
-		return nil, fmt.Errorf("encode error: %w", err)
-	}
-
-	compressed, err := zstd.CompressLevel(nil, buf.Bytes(), 22)
-	if err != nil {
-		return nil, fmt.Errorf("compression error: %w", err)
-	}
-
-	return compressed, nil
-}
-
-func decompressKeys(data []byte) ([][]byte, error) {
-	decompressed, err := zstd.Decompress(nil, data)
-	if err != nil {
-		return nil, fmt.Errorf("decompression error: %w", err)
-	}
-
-	dec := gob.NewDecoder(bytes.NewReader(decompressed))
-
-	var keys [][]byte
-	if err := dec.Decode(&keys); err != nil {
-		return nil, fmt.Errorf("decode error: %w", err)
-	}
-
-	return keys, nil
-}
-
-// FetchAndStore fetches all keys from the local TODO replicate list, fetches value from respective nodes and stores them in the local store
-func (s *DHT) FetchAndStore(ctx context.Context) error {
-	keys, err := s.store.GetAllToDoRepKeys()
-	if err != nil {
-		return fmt.Errorf("get all keys error: %w", err)
-	}
-	log.WithContext(ctx).WithField("count", len(keys)).Info("got keys from local store")
-
-	if len(keys) == 0 {
-		return nil
-	}
-
-	//wg := sync.WaitGroup{}
-	//wg.Add(len(keys))        // Add count of all keys before spawning goroutines
-	var successCounter int32 // Create a counter for successful operations
-
-	for i := 0; i < len(keys); i++ {
-		key := keys[i]
-
-		func(info domain.ToRepKey) {
-			//defer wg.Done()
-			cctx, ccancel := context.WithTimeout(ctx, 30*time.Second)
-			defer ccancel()
-
-			sKey := hex.EncodeToString(info.Key)
-			n := Node{ID: []byte(info.ID), IP: info.IP, Port: info.Port}
-
-			b := backoff.WithMaxRetries(backoff.NewConstantBackOff(2*time.Second), 10)
-			var value []byte // replace with the actual type of "value"
-			err := backoff.Retry(func() error {
-				val, err := s.GetValueFromNode(cctx, info.Key, &n)
-				if err != nil {
-					return err
-				}
-				value = val
-				return nil
-			}, b)
-
-			if err != nil {
-				log.WithContext(cctx).WithField("key", sKey).WithField("ip", info.IP).WithError(err).Error("fetch & store key failed")
-				value, err = s.iterateFindValue(cctx, IterateFindValue, info.Key)
-				if err != nil {
-					log.WithContext(cctx).WithField("key", sKey).WithField("ip", info.IP).WithError(err).Error("iterate fetch for replication failed")
-					return
-				} else if len(value) == 0 {
-					log.WithContext(cctx).WithField("key", sKey).WithField("ip", info.IP).WithError(err).Error("iterate fetch for replication failed 0 val")
-					return
-				} else {
-					log.WithContext(cctx).WithField("key", sKey).WithField("ip", info.IP).Info("iterate fetch for replication success")
-				}
-			}
-
-			if err := s.store.Store(cctx, info.Key, value, 0, false); err != nil {
-				log.WithContext(cctx).WithField("key", sKey).WithField("ip", info.IP).WithError(err).Error("fetch & local store key failed")
-				return
-			}
-
-			if err := s.store.DeleteRepKey(info.Key); err != nil {
-				log.WithContext(cctx).WithField("key", sKey).WithField("ip", info.IP).WithError(err).Error("delete key from todo list failed")
-				return
-			}
-
-			atomic.AddInt32(&successCounter, 1) // Increment the counter atomically
-
-			log.WithContext(cctx).WithField("key", sKey).WithField("ip", info.IP).Info("fetch & store key success")
-		}(key)
-
-		time.Sleep(100 * time.Millisecond)
-	}
-
-	//wg.Wait()
-
-	log.WithContext(ctx).WithField("todo-keys", len(keys)).WithField("successfully-added-keys", atomic.LoadInt32(&successCounter)).Infof("Successfully fetched & stored keys") // Log the final count
-
-	return nil
-}
-
-// Function to generate a key from a node object.
-func generateKeyFromNode(node *Node) string {
-	return string(node.ID) + ":" + node.IP + ":" + fmt.Sprint(node.Port)
-}
-
-// Function to retrieve a node object from a key.
-func getNodeFromKey(key string) (*Node, error) {
-	parts := strings.Split(key, ":")
-
-	if len(parts) != 3 {
-		return nil, fmt.Errorf("invalid key")
-	}
-
-	id := []byte(parts[0])
-	ip := parts[1]
-
-	// strconv.Atoi returns an int and an error, which we need to handle.
-	port, err := strconv.Atoi(parts[2])
-	if err != nil {
-		return nil, fmt.Errorf("invalid port: %w", err)
-	}
-
-	return &Node{ID: id, IP: ip, Port: port}, nil
 }

--- a/p2p/kademlia/store.go
+++ b/p2p/kademlia/store.go
@@ -57,7 +57,7 @@ type Store interface {
 	StoreBatchRepKeys(values [][]byte, id string, ip string, port int) error
 
 	// GetAllToDoRepKeys gets all keys that need to be replicated
-	GetAllToDoRepKeys() (retKeys domain.ToRepKeys, err error)
+	GetAllToDoRepKeys(minAttempts, maxAttempts int) (retKeys domain.ToRepKeys, err error)
 
 	// DeleteRepKey deletes a key from the replication table
 	DeleteRepKey(key []byte) error
@@ -66,4 +66,10 @@ type Store interface {
 	UpdateLastSeen(ctx context.Context, id string) error
 
 	RetrieveBatchNotExist(ctx context.Context, keys [][]byte, batchSize int) ([][]byte, error)
+
+	RetrieveBatchValues(ctx context.Context, keys []string) ([][]byte, int, error)
+
+	BatchDeleteRepKeys(keys []string) error
+
+	IncrementAttempts(keys []string) error
 }

--- a/p2p/kademlia/store/mem/mem.go
+++ b/p2p/kademlia/store/mem/mem.go
@@ -153,7 +153,7 @@ func (s *Store) StoreBatchRepKeys(_ [][]byte, _ string, _ string, _ int) error {
 }
 
 // GetAllToDoRepKeys gets all keys that need to be replicated
-func (s *Store) GetAllToDoRepKeys() (retKeys domain.ToRepKeys, err error) {
+func (s *Store) GetAllToDoRepKeys(_ int, _ int) (retKeys domain.ToRepKeys, err error) {
 	return retKeys, nil
 }
 
@@ -170,4 +170,19 @@ func (s *Store) UpdateLastSeen(_ context.Context, _ string) error {
 // RetrieveBatchNotExist retrieves a batch of keys that do not exist
 func (s *Store) RetrieveBatchNotExist(_ context.Context, _ [][]byte, _ int) ([][]byte, error) {
 	return nil, nil
+}
+
+// RetrieveBatchValues retrieves a batch of values
+func (s *Store) RetrieveBatchValues(_ context.Context, _ []string) ([][]byte, int, error) {
+	return nil, 0, nil
+}
+
+// BatchDeleteRepKeys deletes a batch of keys from the replication table
+func (s *Store) BatchDeleteRepKeys(_ []string) error {
+	return nil
+}
+
+// IncrementAttempts increments the attempts of a key
+func (s *Store) IncrementAttempts(_ []string) error {
+	return nil
 }

--- a/supernode/services/storagechallenge/service.go
+++ b/supernode/services/storagechallenge/service.go
@@ -79,7 +79,7 @@ func (service *SCService) Run(ctx context.Context) error {
 				newCtx := log.ContextWithPrefix(context.Background(), "storage-challenge")
 				//task := service.NewSCTask()
 				//task.GenerateStorageChallenges(newCtx)
-				log.WithContext(newCtx).Info("Would normally generate a storage challenge")
+				log.WithContext(newCtx).Debug("Would normally generate a storage challenge")
 			}
 		case <-ctx.Done():
 			log.Println("Context done being called in generatestoragechallenge loop in service.go")


### PR DESCRIPTION
- New kademlia request/response structure
- Batch fetch requests and response
- optimal compression and response message size to fit in as many keys as possible within the allowed message size range.
- verification of files rcvd as part of replication.
- Add 'attempts' field and make decisions on number of attempts 
- Increase max p2p message payload size to 100MB
- Fix ClosestContacts function to correctly return top 6 nodes in the right order. (comparator wasn't being assigned, the PR fixes that as well)
- Fixed the sorting function and wrote unit tests to test sorting, also tested in practice on testnet.
- Fix the iterate store function to store in top 6 instead of 20 nodes. 
- Re-wrote iterate store function, general code and structural improvements
- Wrote batch fetch for failed replication keys - it will now start with the closest and go up to the 12th closest node for all the keys that were not returned by the nodes that claimed to have it. 

