### PR TITLE
[PSL-1104] [PSL-1108] ]unify SH Metrics and add 2 new APIs for challenge and triggers audit

### DIFF
--- a/common/storage/local.go
+++ b/common/storage/local.go
@@ -14,6 +14,29 @@ type Metrics struct {
 	SHExecutionMetrics []byte
 }
 
+// SHTriggerMetrics represents the self-healing trigger metrics
+type SHTriggerMetrics []SHTriggerMetric
+
+// SHTriggerMetric represents the self-healing execution metrics
+type SHTriggerMetric struct {
+	TriggerID              string `json:"trigger_id"`
+	NodesOffline           int    `json:"nodes_offline"`
+	ListOfNodes            string `json:"list_of_nodes"`
+	TotalFilesIdentified   int    `json:"total_files_identified"`
+	TotalTicketsIdentified int    `json:"total_tickets_identified"`
+}
+
+// SHExecutionMetrics represents the self-healing execution metrics
+type SHExecutionMetrics struct {
+	TotalChallengesIssued     int `json:"total_challenges_issued"`     // sum of challenge tickets in trigger table message_type = 1
+	TotalChallengesRejected   int `json:"total_challenges_rejected"`   // healer node accepted or rejected -- message_type = 2 && is_reconsrcution_req = false
+	TotalChallengesAccepted   int `json:"total_challenges_verified"`   // healer node accepted the challenge -- message_type = 2 && is_reconsrcution_req = true
+	TotalChallengesFailed     int `json:"total_challenges_failed"`     // message_type = 3 and array of self healing message shows < 3 is_verified = true selfhealig verification messages
+	TotalChallengesSuccessful int `json:"total_challenges_successful"` // message_type = 3 and array of self healing message shows >= 3 is_verified = true selfhealig verification messages
+	TotalFilesHealed          int `json:"total_files_healed"`          // message_type = 4
+	TotalFileHealingFailed    int `json:"total_file_healing_failed"`   // message_type !=4
+}
+
 // LocalStoreInterface is interface for local sqlite store
 type LocalStoreInterface interface {
 	InsertTaskHistory(history types.TaskHistory) (int, error)
@@ -35,5 +58,5 @@ type LocalStoreInterface interface {
 	GetAllPingInfoForOnlineNodes() (types.PingInfos, error)
 	UpdatePingInfo(supernodeID string, isOnWatchlist, isAdjusted bool) error
 	CloseHistoryDB(ctx context.Context)
-	QueryMetrics(from time.Time, to *time.Time) (m Metrics, err error)
+	QueryMetrics(ctx context.Context, from time.Time, to *time.Time) (m Metrics, err error)
 }

--- a/common/types/self_healing.go
+++ b/common/types/self_healing.go
@@ -51,6 +51,9 @@ type PingInfo struct {
 // PingInfos represents array of ping info
 type PingInfos []PingInfo
 
+// SelfHealingMessages represents the self-healing metrics for each challenge = message_type = 3
+type SelfHealingMessages []SelfHealingMessage
+
 // SelfHealingMessage represents the self-healing message
 type SelfHealingMessage struct {
 	TriggerID              string                 `json:"trigger_id"`
@@ -60,7 +63,7 @@ type SelfHealingMessage struct {
 	SenderSignature        []byte                 `json:"sender_signature"`
 }
 
-// SelfHealingMessageData represents the self-healing message data
+// SelfHealingMessageData represents the self-healing message data == message_type = 2
 type SelfHealingMessageData struct {
 	ChallengerID string                      `json:"challenger_id"`
 	RecipientID  string                      `json:"recipient_id"`


### PR DESCRIPTION
- Added 2 New APIs

1- /sh_trigger?trigger_id=”abc” to expose self healing trigger audit
2- /sh_challenge?challenge_id=”xyz” to expose self healing challenge audit

- Unified SH metrics data and deliver actual metrics through API exposed on port 8089 of supernode (/metrcis?from="2023-08-13T16:07:54+02:00")  [time format RFC3339]