### PR TITLE
fix edge case in p2p closest contacts calculation

### DIFF
--- a/p2p/kademlia/hashtable.go
+++ b/p2p/kademlia/hashtable.go
@@ -298,11 +298,9 @@ func (ht *HashTable) closestContactsWithInlcudingNode(num int, target []byte, ig
 	}
 
 	// Flatten the routeTable and add nodes to nl if they're not in the ignoredMap
-	counter := 0
 	for _, bucket := range ht.routeTable {
 		for _, node := range bucket {
 			if !ignoredMap[string(node.ID)] {
-				counter++
 				nl.AddNodes([]*Node{node})
 			}
 		}

--- a/p2p/kademlia/hashtable_test.go
+++ b/p2p/kademlia/hashtable_test.go
@@ -105,14 +105,14 @@ func TestClosestContactsWithIncludingNode(t *testing.T) {
 			3YjKEDhanRTxuP1WvEg4PFsq1ejnQuS1NhHRBZWWzxFq3dcUEwKeRdjRBrVU4b9BobvX6LesQRRNYpELhXccYzPmeNiLi69eFCGh4MZ1jK5zU24RSJo2DJ-149.102.147.113:14445,
 			3YjK6FkgW1eZvnVpcbeR5LyazNCmRNKg59yHHdpV52sAHp7c2Np9TVQeoCvZmRciQndXXbSZhVW81mEUunXd6apUbv8Df9Lk7sLRvMMdVd1nWQEYRGi1tu-95.111.253.200:14445,
 			3YjKAnECn9CpGB3kqKEKiEKoisqpyWVYKzDNdQXzTZ97MH4hpg3nyZknEGb3vszNMccQNvGz51yQPtjs2BwWJpCYwPmzJJbs8s7Vy7qiUewaK5Ce5UGBxL-38.242.151.234:14445,
-			3YjKAqro6htwGLENofxUwJ1V1QSsdcPGJ2v4A4zb8AphwVACizg8wFTq4jsJfCGhRznPYb86HqpYFVmGvgDiq6EASrHxFkbkX37JzfDGntvVGLinvZyqz4-154.12.235.19:14445,
 			3YjK6TzKc4beYhe8PQLtMfqFLicDS4PkhZJrb5TgzJQ7EBvRZjfBbo3dVu9SqFd2m6rupfrr5hZEHhNHyySjC5ZozjuqdJfTKEXYzJ4KYWFFmKcwTtiVGe-149.102.147.180:14445,
 			3YjK9rsqRn8jXC4T48J1tdeEGC2XxHw4YNdfLX8PvZyw53ykNdXYU7WSEPHSNkDyg3npdxAPG57vFqLs9yZzrzfrCSvt6uFaUTLV6ReXkVWdZ8SY6YfeHu-95.111.235.112:14445,
 			3YjKA64Z5iLhRN7NEU1P444nMyjAsGtHR3RgdoXMV14evXh6iox3qWDudkbDnwFztk5h8NHQZPZxyFwyv6USyFyoxG8YT3qB1NLU4V1XFFEDkve4ie5gcE-154.12.235.12:14445,
 			3YjKjNzpsUY2RqPqVifHHHtqDstMKExtTjQzT97wozZyDgn9HA3ckxu4dTYdsxw9isrqwMtGjMkPav344cfApLfsMrRBkZRR3n2mRZceY2xjiqnBDBfh3u-149.102.147.122:14445,
 			3YjK6S5YcNWvGUP8YdDKYNXm4xKbXrhd4jkSeD7ZaPgo5tfCWAUPY16fZh7Dp2hCDz1rg35EBgrL2U67pSU3JjQYb4GAjKL2MqsdJ3HM5diQFZTbjZTVR7-154.12.235.16:14445,
-			3YjK6RMKAqFPD99e6EMt514wLRGqoFnKWhqQzpxRZowTHZPVFAuRB2fSLU2eucNyYBrFowFWBQ9hm3x4JBdCSesMJD1vcFYywxohmXET3NwCm3dBTBijxa-3.142.100.245:14445"`,
-			includedNode: nil,
+			3YjK6RMKAqFPD99e6EMt514wLRGqoFnKWhqQzpxRZowTHZPVFAuRB2fSLU2eucNyYBrFowFWBQ9hm3x4JBdCSesMJD1vcFYywxohmXET3NwCm3dBTBijxa-3.142.100.245:14445`,
+			includedNode: &Node{ID: []byte("3YjKAqro6htwGLENofxUwJ1V1QSsdcPGJ2v4A4zb8AphwVACizg8wFTq4jsJfCGhRznPYb86HqpYFVmGvgDiq6EASrHxFkbkX37JzfDGntvVGLinvZyqz4"),
+				IP: "154.12.235.19", Port: 14445},
 			ignoredNodes: make([]*Node, 0),
 			topCount:     6,
 			targetKey:    "517b1003b805793f35f4242f481a48cd45e5431a2af6e10339cbcf97f7b1a27e",
@@ -149,8 +149,10 @@ func TestClosestContactsWithIncludingNode(t *testing.T) {
 			key, err := hex.DecodeString(tc.targetKey)
 			assert.NoError(t, err)
 
+			if tc.includedNode != nil {
+				tc.includedNode.SetHashedID()
+			}
 			result := tc.hashTable.closestContactsWithInlcudingNode(tc.topCount, key, tc.ignoredNodes, tc.includedNode)
-
 			for i, node := range result.Nodes {
 
 				assert.Equal(t, node.IP, tc.expectedResults.Nodes[i].IP)

--- a/p2p/kademlia/node.go
+++ b/p2p/kademlia/node.go
@@ -179,3 +179,16 @@ func (s *NodeList) NodeIDs() [][]byte {
 
 	return toRet
 }
+
+// NodeIPs returns the dump information for node list
+func (s *NodeList) NodeIPs() []string {
+	s.Mux.RLock()
+	defer s.Mux.RUnlock()
+
+	toRet := make([]string, len(s.Nodes))
+	for i := 0; i < len(s.Nodes); i++ {
+		toRet = append(toRet, s.Nodes[i].IP)
+	}
+
+	return toRet
+}

--- a/p2p/kademlia/node_test.go
+++ b/p2p/kademlia/node_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pastelnetwork/gonode/common/log"
+	"github.com/stretchr/testify/assert"
 )
 
 func (s *testSuite) TestHasBit() {
@@ -207,9 +207,6 @@ func TestNodeListSortDetail(t *testing.T) {
 
 	nl2.Sort()
 	results = append(results, nl2)
-
-	log.WithField("results[0]", results[0].String()).Info("results[0]")
-	log.WithField("results[1]", results[1].String()).Info("results[1]")
 	first := results[0]
 	for i := 1; i < len(results); i++ {
 		if len(first.Nodes) != len(results[i].Nodes) {
@@ -222,4 +219,86 @@ func TestNodeListSortDetail(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestNodeListSort(t *testing.T) {
+	hashedComparator, err := hex.DecodeString("a6cc846e5019e845fa58a5af1c16baf96d7921de13375d05e745f266520734ba")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name       string
+		data       string
+		comparator []byte
+	}{
+		{
+			name:       "A",
+			comparator: hashedComparator,
+			data: `3YjK6T7Cc9P29MdUnmZAxv1qYCGcRsNPh4mGmmXYyfVAtKCEjdBGegAMLiKcW47hi4gpGMWE9peM3DRFj7RWwST3x3EP1BrqKjDcdMJBc7xVAF9h1wDwaY-3.19.48.187:14445,
+			3YjK9rsqRn8jXC4T48J1tdeEGC2XxHw4YNdfLX8PvZyw53ykNdXYU7WSEPHSNkDyg3npdxAPG57vFqLs9yZzrzfrCSvt6uFaUTLV6ReXkVWdZ8SY6YfeHu-95.111.235.112:14445,
+			3YjKEC59G1hzBWWhGQivGqvJd27Hj7yyrqBjzBKbYHfKj8ycVTRQjGpMzgWZfucknYvcN1uwtrP1Fr7SMSPnmuBaeCejRfzFoeJPKZRLm76xVWcsAH8HZz-18.189.251.53:14445,
+			3YjKEip9oXJMm8YFiUkhBgv8DbyAjWhzJMZaWqWs3KWhdvnKxQj77gYy2zohN5Fx8Yibzf3v1UbovnUvBTKq64caWDFLEVLMpLVVGFybNARM694t1Wz3h1-3.18.240.77:14445,
+			3YjKAnECn9CpGB3kqKEKiEKoisqpyWVYKzDNdQXzTZ97MH4hpg3nyZknEGb3vszNMccQNvGz51yQPtjs2BwWJpCYwPmzJJbs8s7Vy7qiUewaK5Ce5UGBxL-38.242.151.234:14445,
+			3YjKAqro6htwGLENofxUwJ1V1QSsdcPGJ2v4A4zb8AphwVACizg8wFTq4jsJfCGhRznPYb86HqpYFVmGvgDiq6EASrHxFkbkX37JzfDGntvVGLinvZyqz4-154.12.235.19:14445,
+			3YjKjB1PaGGdsWGoASNhBMs3XxGfFRV5qzqUFD31r8AwtAUcxYZXtnG7AGicRcbKS1LwD79dtRn1f9euS41wNeZNgcUM7GyHKeyU1RmNJbygethBimm9ei-3.130.254.15:14445,
+			3YjKAtueoP1xMZBtH98xGKxDRmqTds58VHS9ev4uZSeTjRUeWyd1qfD99FNkJoKsQxZonjSaSdTNRPWTNqkGhXMxLZjhjzxTHryuJhMQRKJSs97mb2U4im-154.38.161.44:14445,
+			3YjKEDhanRTxuP1WvEg4PFsq1ejnQuS1NhHRBZWWzxFq3dcUEwKeRdjRBrVU4b9BobvX6LesQRRNYpELhXccYzPmeNiLi69eFCGh4MZ1jK5zU24RSJo2DJ-149.102.147.113:14445,
+			3YjK6mqfZDNgbjSaTqPYDtkqsPm4XQ1vezUn7NYqSekpV3c9q9Qjndxaq3UcEmkBEih8iajd7iboPRbAjABqz7Ri6fCdXvETrhU1tFfUZHeJK8vNmZju6D-154.38.160.234:14445,
+			3YjK6FkgW1eZvnVpcbeR5LyazNCmRNKg59yHHdpV52sAHp7c2Np9TVQeoCvZmRciQndXXbSZhVW81mEUunXd6apUbv8Df9Lk7sLRvMMdVd1nWQEYRGi1tu-95.111.253.200:14445,
+			3YjKA64Z5iLhRN7NEU1P444nMyjAsGtHR3RgdoXMV14evXh6iox3qWDudkbDnwFztk5h8NHQZPZxyFwyv6USyFyoxG8YT3qB1NLU4V1XFFEDkve4ie5gcE-154.12.235.12:14445,
+			3YjKDzhn3GVoH5GKfteY39YDYEfzqXpmKDj4uUfEVb2gPSE8n5TgYTg6QDNMZSBsngCT2vrsbvyZf1K9G4FBzKWdRTyLnkpWp2iLTjCvRtb1W8Z2wf7pGg-154.12.235.41:14445,
+			3YjKA58AQ4NPho7kKBCnBUzfUYpurEmyehRToFR7kTZ26JnuJSR2xQAhxzrBHmMwZ4EFCPbkFmde4QVK4GpUEBdxMgoBohHFnGN3hZCwnnD1VQ6e8PHLX2-154.38.161.58:14445,
+			3YjKAkKCwWmoRhHxMnvoyvrg3ncUXcwk2heLuJbjVV2GxxLK5gfWb4A7sCse6ZMEbAu3odVaqguPcZxZRs8fAB2LnSezZjTF9MFMs1zm5de6g8nNm1gGyc-154.38.161.52:14445,
+			3YjK6TzKc4beYhe8PQLtMfqFLicDS4PkhZJrb5TgzJQ7EBvRZjfBbo3dVu9SqFd2m6rupfrr5hZEHhNHyySjC5ZozjuqdJfTKEXYzJ4KYWFFmKcwTtiVGe-149.102.147.180:14445,
+			3YjK6S5YcNWvGUP8YdDKYNXm4xKbXrhd4jkSeD7ZaPgo5tfCWAUPY16fZh7Dp2hCDz1rg35EBgrL2U67pSU3JjQYb4GAjKL2MqsdJ3HM5diQFZTbjZTVR7-154.12.235.16:14445,
+			3YjKjhwUZ1ZskdmJ1n9rU7tKqkgwVQnNcKzaK6rgJPGvEXf4aqGS3boPaH5T2HwdkZYMHEW8YpHASLZTQR3DY3kgJwFBvpUMc2iKecmAp1xymqiyNh4NJ1-38.242.151.208:14445,
+			3YjKAxUb4bbnK6mHPFQe1fmSoSssLBcQjgNEmTWgVWssnk4hkmr3Y8Yd9D1UNJ7PSvnfuwE5NB78G5XxcueqnCfDngfB1ZyuYiAiVgi7e9ZgTgtun8nLS9-149.102.147.66:14445,
+			3YjKjNzpsUY2RqPqVifHHHtqDstMKExtTjQzT97wozZyDgn9HA3ckxu4dTYdsxw9isrqwMtGjMkPav344cfApLfsMrRBkZRR3n2mRZceY2xjiqnBDBfh3u-149.102.147.122:14445,
+			3YjK6RMKAqFPD99e6EMt514wLRGqoFnKWhqQzpxRZowTHZPVFAuRB2fSLU2eucNyYBrFowFWBQ9hm3x4JBdCSesMJD1vcFYywxohmXET3NwCm3dBTBijxa-3.142.100.245:14445`,
+		},
+		{
+			name:       "B",
+			comparator: hashedComparator,
+			data: `3YjKAxUb4bbnK6mHPFQe1fmSoSssLBcQjgNEmTWgVWssnk4hkmr3Y8Yd9D1UNJ7PSvnfuwE5NB78G5XxcueqnCfDngfB1ZyuYiAiVgi7e9ZgTgtun8nLS9-149.102.147.66:14445,
+			3YjKEC59G1hzBWWhGQivGqvJd27Hj7yyrqBjzBKbYHfKj8ycVTRQjGpMzgWZfucknYvcN1uwtrP1Fr7SMSPnmuBaeCejRfzFoeJPKZRLm76xVWcsAH8HZz-18.189.251.53:14445,
+			3YjKA58AQ4NPho7kKBCnBUzfUYpurEmyehRToFR7kTZ26JnuJSR2xQAhxzrBHmMwZ4EFCPbkFmde4QVK4GpUEBdxMgoBohHFnGN3hZCwnnD1VQ6e8PHLX2-154.38.161.58:14445,
+			3YjK6mqfZDNgbjSaTqPYDtkqsPm4XQ1vezUn7NYqSekpV3c9q9Qjndxaq3UcEmkBEih8iajd7iboPRbAjABqz7Ri6fCdXvETrhU1tFfUZHeJK8vNmZju6D-154.38.160.234:14445,
+			3YjKDzhn3GVoH5GKfteY39YDYEfzqXpmKDj4uUfEVb2gPSE8n5TgYTg6QDNMZSBsngCT2vrsbvyZf1K9G4FBzKWdRTyLnkpWp2iLTjCvRtb1W8Z2wf7pGg-154.12.235.41:14445,
+			3YjKAkKCwWmoRhHxMnvoyvrg3ncUXcwk2heLuJbjVV2GxxLK5gfWb4A7sCse6ZMEbAu3odVaqguPcZxZRs8fAB2LnSezZjTF9MFMs1zm5de6g8nNm1gGyc-154.38.161.52:14445,
+			3YjK6T7Cc9P29MdUnmZAxv1qYCGcRsNPh4mGmmXYyfVAtKCEjdBGegAMLiKcW47hi4gpGMWE9peM3DRFj7RWwST3x3EP1BrqKjDcdMJBc7xVAF9h1wDwaY-3.19.48.187:14445,
+			3YjKjB1PaGGdsWGoASNhBMs3XxGfFRV5qzqUFD31r8AwtAUcxYZXtnG7AGicRcbKS1LwD79dtRn1f9euS41wNeZNgcUM7GyHKeyU1RmNJbygethBimm9ei-3.130.254.15:14445,
+			3YjKEip9oXJMm8YFiUkhBgv8DbyAjWhzJMZaWqWs3KWhdvnKxQj77gYy2zohN5Fx8Yibzf3v1UbovnUvBTKq64caWDFLEVLMpLVVGFybNARM694t1Wz3h1-3.18.240.77:14445,
+			3YjKjhwUZ1ZskdmJ1n9rU7tKqkgwVQnNcKzaK6rgJPGvEXf4aqGS3boPaH5T2HwdkZYMHEW8YpHASLZTQR3DY3kgJwFBvpUMc2iKecmAp1xymqiyNh4NJ1-38.242.151.208:14445,
+			3YjKAtueoP1xMZBtH98xGKxDRmqTds58VHS9ev4uZSeTjRUeWyd1qfD99FNkJoKsQxZonjSaSdTNRPWTNqkGhXMxLZjhjzxTHryuJhMQRKJSs97mb2U4im-154.38.161.44:14445,
+			3YjKEDhanRTxuP1WvEg4PFsq1ejnQuS1NhHRBZWWzxFq3dcUEwKeRdjRBrVU4b9BobvX6LesQRRNYpELhXccYzPmeNiLi69eFCGh4MZ1jK5zU24RSJo2DJ-149.102.147.113:14445,
+			3YjK6FkgW1eZvnVpcbeR5LyazNCmRNKg59yHHdpV52sAHp7c2Np9TVQeoCvZmRciQndXXbSZhVW81mEUunXd6apUbv8Df9Lk7sLRvMMdVd1nWQEYRGi1tu-95.111.253.200:14445,
+			3YjKAnECn9CpGB3kqKEKiEKoisqpyWVYKzDNdQXzTZ97MH4hpg3nyZknEGb3vszNMccQNvGz51yQPtjs2BwWJpCYwPmzJJbs8s7Vy7qiUewaK5Ce5UGBxL-38.242.151.234:14445,
+			3YjKAqro6htwGLENofxUwJ1V1QSsdcPGJ2v4A4zb8AphwVACizg8wFTq4jsJfCGhRznPYb86HqpYFVmGvgDiq6EASrHxFkbkX37JzfDGntvVGLinvZyqz4-154.12.235.19:14445,
+			3YjK6TzKc4beYhe8PQLtMfqFLicDS4PkhZJrb5TgzJQ7EBvRZjfBbo3dVu9SqFd2m6rupfrr5hZEHhNHyySjC5ZozjuqdJfTKEXYzJ4KYWFFmKcwTtiVGe-149.102.147.180:14445,
+			3YjK9rsqRn8jXC4T48J1tdeEGC2XxHw4YNdfLX8PvZyw53ykNdXYU7WSEPHSNkDyg3npdxAPG57vFqLs9yZzrzfrCSvt6uFaUTLV6ReXkVWdZ8SY6YfeHu-95.111.235.112:14445,
+			3YjKA64Z5iLhRN7NEU1P444nMyjAsGtHR3RgdoXMV14evXh6iox3qWDudkbDnwFztk5h8NHQZPZxyFwyv6USyFyoxG8YT3qB1NLU4V1XFFEDkve4ie5gcE-154.12.235.12:14445,
+			3YjKjNzpsUY2RqPqVifHHHtqDstMKExtTjQzT97wozZyDgn9HA3ckxu4dTYdsxw9isrqwMtGjMkPav344cfApLfsMrRBkZRR3n2mRZceY2xjiqnBDBfh3u-149.102.147.122:14445,
+			3YjK6S5YcNWvGUP8YdDKYNXm4xKbXrhd4jkSeD7ZaPgo5tfCWAUPY16fZh7Dp2hCDz1rg35EBgrL2U67pSU3JjQYb4GAjKL2MqsdJ3HM5diQFZTbjZTVR7-154.12.235.16:14445,
+			3YjK6RMKAqFPD99e6EMt514wLRGqoFnKWhqQzpxRZowTHZPVFAuRB2fSLU2eucNyYBrFowFWBQ9hm3x4JBdCSesMJD1vcFYywxohmXET3NwCm3dBTBijxa-3.142.100.245:14445`,
+		},
+	}
+
+	// Pre-compute the hashed IDs for the nodes.
+
+	nl1 := CreateNodeList(tests[0].data)
+	nl2 := CreateNodeList(tests[1].data)
+
+	nl1.Comparator = tests[0].comparator
+	nl2.Comparator = tests[1].comparator
+	nl1.debug = true
+	nl2.debug = true
+
+	nl1.Sort()
+	nl1.TopN(6)
+
+	nl2.Sort()
+	nl2.TopN(6)
+
+	assert.Equal(t, nl1.String(), nl2.String())
 }

--- a/p2p/kademlia/replication.go
+++ b/p2p/kademlia/replication.go
@@ -166,8 +166,10 @@ func (s *DHT) Replicate(ctx context.Context) {
 	ignores := s.ignorelist.ToNodeList()
 	closestContactsMap := make(map[string][][]byte)
 
+	self := &Node{ID: s.ht.self.ID, IP: s.externalIP, Port: s.ht.self.Port}
+	self.SetHashedID()
+
 	for i := 0; i < len(replicationKeys); i++ {
-		self := &Node{ID: s.ht.self.ID, IP: s.externalIP, Port: s.ht.self.Port}
 		decKey, _ := hex.DecodeString(replicationKeys[i].Key)
 		closestContactsMap[replicationKeys[i].Key] = s.ht.closestContactsWithInlcudingNode(Alpha, decKey, ignores, self).NodeIDs()
 	}
@@ -290,6 +292,7 @@ func (s *DHT) adjustNodeKeys(ctx context.Context, from time.Time, info domain.No
 	for i := 0; i < len(replicationKeys); i++ {
 
 		offNode := &Node{ID: []byte(info.ID), IP: info.IP, Port: info.Port}
+		offNode.SetHashedID()
 
 		// get closest contacts to the key
 		key, _ := hex.DecodeString(replicationKeys[i].Key)


### PR DESCRIPTION
- This PR aims to fix an edge case in kademlia's closest contacts calculation algorithm.
   When we provide a node that is to be included in the calculation necessarily regardless of the state of the node's own routing 
   table, it doesn't compare XOR distance based on hash of the node ID. 

- Adds some additional unit tests.